### PR TITLE
Fix Aora mobile alignment and repeated API requests

### DIFF
--- a/aora-v8-final/app/features-v2-fixes.css
+++ b/aora-v8-final/app/features-v2-fixes.css
@@ -1,4 +1,127 @@
 .u-update-banner{top:12px;right:12px;left:auto;bottom:auto;transform:none;width:min(320px,calc(100vw - 24px));box-sizing:border-box;pointer-events:none}
 .u-update-banner button{pointer-events:auto}
-@media(max-width:900px){.u-update-banner{display:none!important}}
+
+/* Responsive foundations shared by Owner, Manager and Employee surfaces. */
+.admin-main,.admin-content,.employee-main,.u-calendar-shell,.u-schedule-shell,.u-task-shell{min-width:0;max-width:100%}
+.u-toolbar>div,.u-toolbar-group,.u-item-card,.u-task-row,.u-task-detail,.u-field{min-width:0}
+.u-item-card h3,.u-item-card p,.u-task-row strong,.u-task-row small,.u-toolbar h1,.u-toolbar h2{overflow-wrap:anywhere}
+.u-field input,.u-field select,.u-field textarea{width:100%;max-width:100%;box-sizing:border-box}
+
 @media(min-width:901px){.u-update-banner{top:auto;right:auto;left:50%;bottom:20px;transform:translateX(-50%)}}
+
+@media(max-width:900px){
+  .u-update-banner{display:none!important}
+  .admin-topbar{position:sticky;top:0;z-index:35;height:auto;min-height:66px;padding:10px 14px;gap:10px}
+  .admin-topbar>div:first-child{min-width:0}
+  .admin-topbar h1{font-size:14px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+  .admin-top-actions{gap:7px;flex:none}
+  .admin-content{width:100%;padding:16px 14px 92px;overflow:hidden}
+  .admin-page-head{align-items:flex-start;gap:12px;flex-direction:column}
+  .admin-page-head h1{font-size:25px}
+  .admin-page-head>.actions,.admin-page-head>.btn{width:100%}
+  .admin-kpis{grid-template-columns:repeat(2,minmax(0,1fr))}
+  .admin-kpi{min-height:82px;padding:14px 12px;gap:9px}
+  .admin-kpi strong{font-size:18px}
+  .admin-dashboard{gap:12px}
+  .data-table{display:block;max-width:100%;overflow-x:auto;-webkit-overflow-scrolling:touch}
+  .initial-bar,.status-chip{min-width:0;max-width:100%}
+  .hours-row{grid-template-columns:minmax(110px,1fr) minmax(100px,2fr) 56px}
+  .u-toolbar{display:grid;grid-template-columns:minmax(0,1fr);align-items:stretch;gap:11px;margin-bottom:14px}
+  .u-toolbar-group{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));width:100%;gap:8px}
+  .u-toolbar-group>.u-btn,.u-toolbar-group>.u-icon-btn{width:100%;min-width:0}
+  .u-toolbar-group>.u-icon-btn{height:42px}
+  .u-segmented{grid-column:1/-1;display:grid;grid-template-columns:repeat(3,minmax(0,1fr));width:100%}
+  .u-segmented button{min-width:0}
+  .u-board-summary{grid-template-columns:repeat(2,minmax(0,1fr))}
+  .u-summary-card{min-width:0;padding:12px}
+  .u-summary-card strong{font-size:18px}
+  .u-detail-grid,.u-template-grid{grid-template-columns:1fr}
+  .u-task-layout{grid-template-columns:1fr}
+  .u-task-list{max-height:240px;overflow:auto;-webkit-overflow-scrolling:touch}
+  .u-task-detail{min-height:0;padding:15px}
+  .u-dialog-backdrop{align-items:end;padding:0;background:rgba(0,0,0,.52)}
+  .u-dialog{width:100%;max-width:none;max-height:92dvh;border-radius:20px 20px 0 0;padding:18px 15px max(18px,env(safe-area-inset-bottom));overscroll-behavior:contain}
+  .u-dialog-footer{position:sticky;bottom:calc(-1 * max(18px,env(safe-area-inset-bottom)));z-index:2;display:grid;grid-template-columns:1fr 1fr;margin:18px -15px 0;padding:12px 15px max(12px,env(safe-area-inset-bottom));background:#fff;border-top:1px solid #eceef0}
+  .u-dialog-footer .u-btn{width:100%;min-height:46px}
+  .u-form-grid{grid-template-columns:1fr}
+  .u-field.full{grid-column:auto}
+  .u-field input,.u-field select,.u-field textarea,.input,.select,.textarea{min-height:48px;font-size:16px}
+}
+
+@media(max-width:700px){
+  html,body{max-width:100%;overflow-x:hidden}
+  .employee-main{max-width:none;width:100%;padding:18px 12px calc(88px + env(safe-area-inset-bottom))}
+  .employee-header{height:62px;padding:0 10px}
+  .employee-header-actions{gap:5px}
+  .employee-header-actions .circle-btn{width:38px;height:38px}
+  .employee-page-title{display:grid;grid-template-columns:minmax(0,1fr) auto;align-items:start;gap:9px}
+  .employee-page-title h1{font-size:24px;line-height:1.12}
+  .employee-bottom{display:flex;grid-template-columns:none;height:calc(68px + env(safe-area-inset-bottom));padding-bottom:env(safe-area-inset-bottom)}
+  .employee-bottom button{flex:1 1 0;min-width:0;padding:4px 1px;font-size:8px}
+  .employee-bottom button span{max-width:100%;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+  .employee-bottom button .icon,.employee-bottom button svg{width:18px;height:18px}
+  .mobile-row{align-items:flex-start;padding:12px;gap:8px}
+  .profile-summary{min-width:0}
+  .admin-content{padding:12px 10px 88px}
+  .admin-topbar{padding:9px 10px}
+  .admin-top-actions .circle-btn{width:38px;height:38px}
+  .admin-kpis{grid-template-columns:1fr 1fr;gap:8px}
+  .admin-kpi{display:grid;grid-template-columns:auto minmax(0,1fr);min-height:78px;padding:11px 9px}
+  .admin-kpi .metric-icon{width:36px;height:36px}
+  .dashboard-card-head{height:auto;min-height:58px;padding:11px 13px;gap:8px}
+  .dashboard-body{padding:10px 12px}
+  .duty-row,.schedule-row,.leave-row,.hours-row{min-width:0}
+  .hours-row{grid-template-columns:1fr;gap:7px;padding:10px 0}
+  .hours-row>*{min-width:0}
+  .initial-bar{width:100%}
+  .status-chip{width:auto;justify-self:start;padding:0 11px}
+  .invitation-row,.employee-admin-row{padding:11px;gap:9px}
+  .invitation-row .row-copy,.employee-admin-row .row-copy{min-width:0;flex:1 1 160px}
+  .invite-actions{width:100%;margin-left:0;display:grid;grid-template-columns:repeat(2,minmax(0,1fr))}
+  .invite-actions .btn,.employee-admin-row .btn{width:100%}
+  .owner-hero{padding:22px 18px;border-radius:17px;gap:18px}
+  .owner-hero h1{font-size:29px}
+  .owner-location-list{padding:5px 10px 12px}
+  .owner-location-row{gap:8px;min-height:72px}
+  .location-card,.manager-card{min-height:0;padding:16px}
+  .location-card dl{grid-template-columns:1fr;gap:6px}
+  .section-context{align-items:flex-start;flex-wrap:wrap;padding:11px 12px}
+  .section-context .link-btn{margin-left:0;width:100%}
+  .u-toolbar h1{font-size:24px;line-height:1.15}
+  .u-toolbar-group{grid-template-columns:repeat(2,minmax(0,1fr))}
+  .u-toolbar-group>.u-btn{min-height:44px;padding:8px 9px;font-size:11px;line-height:1.2;white-space:normal}
+  .u-actions{display:grid;grid-template-columns:1fr;width:100%;gap:7px}
+  .u-actions .u-btn{width:100%;min-height:44px}
+  .u-day-detail{padding:14px 12px;border-radius:15px}
+  .u-item-card{padding:12px;border-radius:13px}
+  .u-empty{padding:20px 12px}
+  .u-board-summary{gap:8px}
+  .u-schedule-board{margin-inline:-10px;border-left:0;border-right:0;border-radius:0;scrollbar-width:thin;scroll-snap-type:x proximity;-webkit-overflow-scrolling:touch}
+  .u-schedule-grid{grid-template-columns:108px repeat(7,112px);min-width:892px}
+  .u-grid-cell{min-height:78px;padding:6px}
+  .u-grid-head{font-size:9px}
+  .u-employee-cell{max-width:108px;overflow:hidden}
+  .u-employee-cell strong,.u-employee-cell small{display:block;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+  .u-shift-card{padding:7px 6px;margin-bottom:5px}
+  .u-shift-card strong{font-size:11px}
+  .u-shift-card small{font-size:9px}
+  .u-task-row{padding:12px}
+  .u-task-detail{padding:12px}
+  .u-task-item{padding:11px;margin:8px 0}
+  .u-task-item input[type=checkbox]{width:24px;height:24px}
+  .u-sync-chip{white-space:nowrap}
+  .u-update-banner{display:none!important}
+  .toast-root,#toast-root{left:10px;right:10px;bottom:calc(78px + env(safe-area-inset-bottom))}
+  .toast{max-width:none;width:100%}
+}
+
+@media(max-width:420px){
+  .admin-kpis{grid-template-columns:1fr}
+  .u-toolbar-group{grid-template-columns:1fr 1fr}
+  .u-board-summary{grid-template-columns:1fr 1fr}
+  .u-summary-card{padding:10px}
+  .u-summary-card strong{font-size:17px}
+  .employee-page-title{grid-template-columns:1fr}
+  .employee-page-title .u-sync-chip{justify-self:start}
+  .u-dialog-footer{grid-template-columns:1fr}
+}

--- a/aora-v8-final/app/index.html
+++ b/aora-v8-final/app/index.html
@@ -17,7 +17,7 @@
 <link rel="stylesheet" href="rule-engine.css?v=810">
 <link rel="stylesheet" href="compliance.css?v=814">
 <link rel="stylesheet" href="features-v2.css?v=823">
-<link rel="stylesheet" href="features-v2-fixes.css?v=824">
+<link rel="stylesheet" href="features-v2-fixes.css?v=825">
 </head>
 <body>
 <div id="app"><p role="status">AoraAI wird geladen …</p></div>
@@ -54,7 +54,7 @@
 <script src="modules/compliance.js?v=813" defer></script>
 <script src="modules/worker-config.js?v=823" defer></script>
 <script src="modules/unified-features.js?v=823" defer></script>
-<script src="modules/unified-runtime-fixes.js?v=824" defer></script>
+<script src="modules/unified-runtime-fixes.js?v=825" defer></script>
 <script src="modules/handlers.js?v=822" defer></script>
 <script src="modules/boot.js?v=821" defer></script>
 </body>

--- a/aora-v8-final/app/modules/unified-runtime-fixes.js
+++ b/aora-v8-final/app/modules/unified-runtime-fixes.js
@@ -1,6 +1,68 @@
 "use strict";
 
-if(typeof CFG!=="undefined")CFG.domainFunction="aora-v8-domain-api-compat";
+if(typeof CFG!=="undefined")CFG.domainFunction="aora-v8-domain-api";
+
+// Use the compatibility endpoint only for task reads. All other actions go directly
+// to the domain API, avoiding an extra Edge Function hop on normal navigation.
+if(typeof globalThis.uCall==="function"&&typeof globalThis.request==="function"){
+  const readActions=new Set(["flags","calendar","scheduleBoard","taskTemplates","taskRules","tasks"]);
+  const inFlight=new Map();
+  const cache=new Map();
+  const stable=value=>{
+    if(Array.isArray(value))return value.map(stable);
+    if(value&&typeof value==="object")return Object.keys(value).sort().reduce((out,key)=>(out[key]=stable(value[key]),out),{});
+    return value;
+  };
+  const ttlFor=action=>action==="flags"?60000:["taskTemplates","taskRules"].includes(action)?30000:10000;
+  globalThis.uCall=async function(action,payload={},feature=false){
+    if(!S.session?.token)throw new Error("Sitzung fehlt.");
+    const read=readActions.has(action)&&!feature;
+    const functionName=feature?CFG.featureFunction:(action==="tasks"?"aora-v8-domain-api-compat":CFG.domainFunction);
+    const key=read?JSON.stringify([functionName,action,S.session.subjectId||"",S.locationId||"",stable(payload)]):"";
+    const cached=read?cache.get(key):null;
+    if(cached&&cached.expires>Date.now())return cached.data;
+    if(read&&inFlight.has(key))return inFlight.get(key);
+    if(!read)cache.clear();
+    const job=(async()=>{
+      const envelope=await request(functionName,{action,token:S.session.token,...payload});
+      if(envelope?.error)throw Object.assign(new Error(envelope.error.message||"Aktion fehlgeschlagen."),{data:envelope});
+      const data=envelope?.data;
+      if(read)cache.set(key,{data,expires:Date.now()+ttlFor(action)});
+      return data;
+    })();
+    if(read)inFlight.set(key,job);
+    try{return await job}finally{if(read)inFlight.delete(key)}
+  };
+}
+
+// An empty task list is still a loaded result. The previous length check caused a
+// fresh API request on every render when an employee had no tasks.
+if(typeof globalThis.uEnsureEmployeeTasks==="function"){
+  globalThis.uEnsureEmployeeTasks=async function(force=false){
+    if(!uFlag("task_automation"))return;
+    const from=uAdd(berlin().date,-14),to=uAdd(berlin().date,45);
+    const key=`${S.session?.subjectId||""}:${from}:${to}`;
+    if(S.u.tasks.loading)return;
+    if(!force&&S.u.tasks.employeeKey===key)return;
+    S.u.tasks.loading=true;S.u.tasks.error="";render();
+    try{
+      S.u.tasks.data=await uCall("tasks",{from,to});
+      S.u.tasks.employeeKey=key;
+      if(!S.u.tasks.selected&&S.u.tasks.data.length)S.u.tasks.selected=S.u.tasks.data[0].id;
+    }catch(error){S.u.tasks.error=uErrorMessage(error)}
+    finally{S.u.tasks.loading=false;render()}
+  };
+}
+
+// Warm the production API connection before the first authenticated request.
+if(typeof CFG!=="undefined"&&CFG.url&&document.head&&!document.querySelector('link[data-aora-api-preconnect]')){
+  try{
+    const origin=new URL(CFG.url).origin;
+    const link=document.createElement("link");
+    link.rel="preconnect";link.href=origin;link.crossOrigin="anonymous";link.dataset.aoraApiPreconnect="";
+    document.head.appendChild(link);
+  }catch{}
+}
 
 // The legacy offline module may already have registered /sw.js. Reuse that registration
 // and configure it instead of creating an immediately waiting worker with a second URL.

--- a/aora-v8-final/docs/mobile-performance-fix-20260731.md
+++ b/aora-v8-final/docs/mobile-performance-fix-20260731.md
@@ -1,0 +1,9 @@
+# Mobile and performance fix — 2026-07-31
+
+- Direct Domain API routing for normal reads and mutations.
+- Compatibility endpoint retained only for enriched task reads.
+- In-flight request deduplication and short-lived read caching.
+- Empty employee task lists are treated as loaded results.
+- Responsive Owner, Manager and Employee layouts down to 320px.
+- Adaptive employee bottom navigation for the additional Tasks tab.
+- Mobile schedule board, dialogs, forms, toolbars, tables and action groups.


### PR DESCRIPTION
## Fixes
- route normal reads and mutations directly to the production Domain API
- keep task compatibility enrichment only for task reads
- deduplicate in-flight reads and add short-lived client caching
- stop empty employee task lists from refetching on every render
- make Employee bottom navigation adapt to the added Tasks tab
- align Owner, Manager and Employee layouts from 320px upward
- convert mobile dialogs to bottom sheets and normalize forms/buttons
- make schedule board, KPIs, tables, task panels and action groups mobile-safe

## Validation
- JavaScript syntax checked locally
- CSS brace integrity checked locally
- full GitHub browser/release gate required before merge