### PR TITLE
Aora employee calendar redesign

### DIFF
--- a/aora-v8-final/app/calendar-aora-redesign.css
+++ b/aora-v8-final/app/calendar-aora-redesign.css
@@ -1,0 +1,149 @@
+.aora-calendar-page{
+  --aora-cal-navy:#071c38;
+  --aora-cal-navy-2:#0d2c50;
+  --aora-cal-mint:#6ee7b7;
+  --aora-cal-mint-soft:#dff9ec;
+  --aora-cal-coral:#ef665d;
+  --aora-cal-amber:#f3b34c;
+  --aora-cal-ink:#10213a;
+  --aora-cal-muted:#748094;
+  width:min(100%,980px);
+  margin:0 auto;
+  color:var(--aora-cal-ink);
+}
+.aora-cal-header{position:relative;display:flex;align-items:center;justify-content:space-between;gap:18px;margin:0 0 22px;padding:2px 2px 0}
+.aora-cal-month-wrap,.aora-cal-filter-wrap{position:relative}
+.aora-cal-month{display:inline-flex;align-items:center;gap:6px;border:0;background:transparent;color:var(--aora-cal-navy);font:700 clamp(28px,4vw,42px)/1.1 Sora,Manrope,sans-serif;padding:8px 4px;cursor:pointer}
+.aora-cal-month .material-symbols-rounded{font-size:.82em;color:#6e7989;transition:transform .2s ease}
+.aora-cal-month[aria-expanded=true] .material-symbols-rounded{transform:rotate(180deg)}
+.aora-cal-header-actions{display:flex;align-items:center;gap:9px}
+.aora-cal-icon-button{width:46px;height:46px;display:grid;place-items:center;border:1px solid rgba(7,28,56,.08);border-radius:14px;background:rgba(255,255,255,.88);color:#667287;box-shadow:0 8px 26px rgba(21,39,68,.08);cursor:pointer;transition:transform .18s ease,background .18s ease,color .18s ease,box-shadow .18s ease}
+.aora-cal-icon-button:hover{transform:translateY(-1px);box-shadow:0 12px 30px rgba(21,39,68,.12)}
+.aora-cal-icon-button.is-active{background:var(--aora-cal-navy);color:#fff;box-shadow:0 12px 28px rgba(7,28,56,.22)}
+.aora-cal-icon-button .material-symbols-rounded{font-size:25px}
+.aora-cal-popover{position:absolute;top:calc(100% + 10px);z-index:80;min-width:230px;padding:10px;border:1px solid rgba(7,28,56,.08);border-radius:18px;background:rgba(255,255,255,.98);box-shadow:0 22px 60px rgba(7,28,56,.18);backdrop-filter:blur(18px)}
+.aora-cal-month-popover{left:0}
+.aora-cal-filter-popover{right:0}
+.aora-cal-popover>strong{display:block;padding:7px 10px 10px;font-size:12px;color:var(--aora-cal-muted);text-transform:uppercase;letter-spacing:.08em}
+.aora-cal-popover button{width:100%;min-height:42px;display:flex;align-items:center;justify-content:space-between;gap:10px;border:0;border-radius:12px;background:transparent;color:var(--aora-cal-ink);padding:9px 10px;font:600 13px/1.2 Manrope,sans-serif;text-align:left;cursor:pointer}
+.aora-cal-popover button:hover{background:#f5f7fa}
+.aora-cal-popover button span{display:flex;align-items:center;gap:9px}
+.aora-cal-popover button .material-symbols-rounded{font-size:19px;color:#617087}
+.aora-cal-popover button>i{width:34px;height:20px;position:relative;flex:none;border-radius:999px;background:#d8dee7;transition:background .2s ease}
+.aora-cal-popover button>i:after{content:"";position:absolute;top:3px;left:3px;width:14px;height:14px;border-radius:50%;background:#fff;box-shadow:0 1px 4px rgba(0,0,0,.18);transition:transform .2s ease}
+.aora-cal-popover button>i.is-on{background:#3ec98d}
+.aora-cal-popover button>i.is-on:after{transform:translateX(14px)}
+.aora-cal-body{min-width:0}
+.aora-calendar-grid{display:grid;grid-template-columns:repeat(7,minmax(0,1fr));gap:4px 8px;padding:0 2px}
+.aora-cal-weekday{display:grid;place-items:center;min-height:40px;color:#5f6877;font:600 13px/1 Manrope,sans-serif}
+.aora-cal-day{position:relative;isolation:isolate;min-width:0;min-height:72px;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:7px;border:0;border-radius:18px;background:transparent;color:var(--aora-cal-ink);font:500 16px/1 Manrope,sans-serif;cursor:pointer;-webkit-tap-highlight-color:transparent}
+.aora-cal-day:before{content:"";position:absolute;z-index:-2;inset:7px 1px;border-radius:999px;background:transparent}
+.aora-cal-day.has-range:before{background:linear-gradient(90deg,#d7f8e9,#c7f2dc)}
+.aora-cal-day.range-start:before{left:10%;border-radius:999px 0 0 999px}
+.aora-cal-day.range-continues:before{right:-8px;border-radius:999px 0 0 999px}
+.aora-cal-day.range-middle:before{left:-8px;border-radius:0}
+.aora-cal-day.range-middle.range-end:before{right:10%;border-radius:0 999px 999px 0}
+.aora-cal-day.range-start.range-end:before{left:14%;right:14%;border-radius:999px}
+.aora-cal-day-number{position:relative;z-index:2;width:42px;height:42px;display:grid;place-items:center;border-radius:50%;transition:background .18s ease,color .18s ease,transform .18s ease,box-shadow .18s ease}
+.aora-cal-day:hover .aora-cal-day-number{background:#eef3f7}
+.aora-cal-day.is-selected .aora-cal-day-number{background:linear-gradient(145deg,var(--aora-cal-navy),var(--aora-cal-navy-2));color:#fff;box-shadow:0 10px 24px rgba(7,28,56,.25);transform:scale(1.04)}
+.aora-cal-day.is-today:not(.is-selected) .aora-cal-day-number{box-shadow:inset 0 0 0 2px var(--aora-cal-mint);font-weight:800}
+.aora-cal-day.is-outside{color:#a8afb9}
+.aora-cal-dots{height:7px;display:flex;align-items:center;justify-content:center;gap:3px;position:relative;z-index:2}
+.aora-cal-dot{width:5px;height:5px;border-radius:50%;background:#9aa5b4}
+.aora-cal-dot.is-shift{background:var(--aora-cal-coral)}
+.aora-cal-dot.is-time{background:#24a76e}
+.aora-cal-dot.is-task{background:var(--aora-cal-amber)}
+.aora-cal-dot.is-leave{background:#55c99b}
+.aora-cal-dot.is-open{background:#7e66d5}
+.aora-cal-sheet{position:relative;margin:28px 0 0;padding:28px 28px 22px;border:1px solid rgba(7,28,56,.07);border-radius:30px;background:linear-gradient(180deg,rgba(255,255,255,.98),rgba(248,251,252,.98));box-shadow:0 22px 70px rgba(7,28,56,.12)}
+.aora-cal-handle{position:absolute;top:10px;left:50%;width:50px;height:5px;border-radius:999px;background:#d9dee5;transform:translateX(-50%)}
+.aora-cal-sheet-head{display:flex;align-items:center;justify-content:space-between;gap:18px;margin:5px 0 18px}
+.aora-cal-sheet-head h2{margin:0;color:var(--aora-cal-navy);font:700 clamp(22px,3vw,30px)/1.15 Sora,Manrope,sans-serif;text-transform:none}
+.aora-cal-sheet-head p{margin:7px 0 0;color:var(--aora-cal-muted);font:600 13px/1.2 Manrope,sans-serif}
+.aora-cal-add{width:52px;height:52px;display:grid;place-items:center;flex:none;border:0;border-radius:17px;background:var(--aora-cal-mint-soft);color:#159761;box-shadow:0 10px 28px rgba(62,201,141,.18);cursor:pointer}
+.aora-cal-add .material-symbols-rounded{font-size:29px}
+.aora-cal-summary{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:10px;margin:0 0 14px}
+.aora-cal-summary>div{min-width:0;display:grid;grid-template-columns:auto minmax(0,1fr);grid-template-areas:"icon value" "icon label";align-items:center;column-gap:9px;padding:13px 14px;border-radius:16px;background:#f5f7f9}
+.aora-cal-summary span{grid-area:icon;width:34px;height:34px;display:grid;place-items:center;border-radius:11px;background:#fff;color:#798597}
+.aora-cal-summary span .material-symbols-rounded{font-size:19px}
+.aora-cal-summary strong{grid-area:value;min-width:0;color:var(--aora-cal-navy);font:700 15px/1.1 Manrope,sans-serif;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.aora-cal-summary small{grid-area:label;color:var(--aora-cal-muted);font:500 10px/1.2 Manrope,sans-serif}
+.aora-cal-entry-list{display:grid;gap:11px}
+.aora-cal-entry{position:relative;min-width:0;display:grid;grid-template-columns:48px minmax(0,1fr) auto;align-items:center;gap:14px;padding:16px 18px;border:1px solid rgba(7,28,56,.07);border-radius:18px;background:#fff;box-shadow:0 10px 28px rgba(19,42,74,.06);overflow:hidden}
+.aora-cal-entry:before{content:"";position:absolute;left:0;top:0;bottom:0;width:4px;background:var(--aora-cal-navy)}
+.aora-cal-entry-shift:before{background:var(--aora-cal-mint)}
+.aora-cal-entry-task:before{background:var(--aora-cal-amber)}
+.aora-cal-entry-leave:before{background:#7bcfb0}
+.aora-cal-entry-icon{width:46px;height:46px;display:grid;place-items:center;border-radius:15px;background:#edf2f6;color:var(--aora-cal-navy)}
+.aora-cal-entry-shift .aora-cal-entry-icon{background:var(--aora-cal-mint-soft);color:#15825a}
+.aora-cal-entry-task .aora-cal-entry-icon{background:#fff5dd;color:#a86e0b}
+.aora-cal-entry-leave .aora-cal-entry-icon{background:#e8f8f2;color:#2e8d6b}
+.aora-cal-entry-icon .material-symbols-rounded{font-size:24px}
+.aora-cal-entry-copy{min-width:0;display:flex;flex-direction:column;gap:3px}
+.aora-cal-entry-copy strong{color:var(--aora-cal-navy);font:700 16px/1.2 Manrope,sans-serif;overflow-wrap:anywhere}
+.aora-cal-entry-copy span,.aora-cal-entry-copy small{color:var(--aora-cal-muted);font:500 12px/1.3 Manrope,sans-serif;overflow-wrap:anywhere}
+.aora-cal-entry-value{padding-left:10px;color:var(--aora-cal-navy);font:700 17px/1 Manrope,sans-serif;white-space:nowrap}
+.aora-cal-entry>.u-actions{grid-column:2/-1;display:flex;flex-wrap:wrap;gap:7px;margin-top:4px}
+.aora-cal-entry>.u-actions .u-btn{min-height:38px}
+.aora-cal-entry>.u-btn{min-width:84px}
+.aora-cal-empty{display:grid;place-items:center;gap:7px;padding:24px;border:1px dashed #d8dee7;border-radius:18px;color:var(--aora-cal-muted);text-align:center}
+.aora-cal-empty .material-symbols-rounded{font-size:32px;color:#8fcfb5}
+.aora-cal-empty strong{color:var(--aora-cal-navy)}
+.aora-cal-empty span{font-size:12px}
+.aora-cal-day-total{display:flex;align-items:baseline;justify-content:flex-end;gap:8px;margin:14px 2px 0;padding-top:14px;border-top:1px solid #e6e9ee;color:var(--aora-cal-muted);font:600 12px/1 Manrope,sans-serif}
+.aora-cal-day-total strong{color:var(--aora-cal-navy);font-size:17px}
+.aora-cal-day-total small{text-transform:uppercase;letter-spacing:.06em}
+.aora-calendar-page[data-calendar-mode=week] .aora-cal-body,.aora-calendar-page[data-calendar-mode=list] .aora-cal-body{padding-top:4px}
+.aora-calendar-page .u-list-view,.aora-calendar-page .u-detail-grid{margin-top:8px}
+
+@media(max-width:700px){
+  .employee-main:has(.aora-calendar-page){padding-top:10px}
+  .aora-calendar-page{width:100%}
+  .aora-cal-header{margin-bottom:10px;padding:0}
+  .aora-cal-month{font-size:30px;padding-left:0}
+  .aora-cal-header-actions{gap:6px}
+  .aora-cal-icon-button{width:42px;height:42px;border-radius:13px;box-shadow:0 6px 18px rgba(21,39,68,.07)}
+  .aora-cal-icon-button .material-symbols-rounded{font-size:23px}
+  .aora-cal-popover{position:fixed;left:12px;right:12px;top:auto;bottom:calc(82px + env(safe-area-inset-bottom));min-width:0;max-height:60dvh;overflow:auto;z-index:150;border-radius:20px}
+  .aora-calendar-grid{gap:0;padding:0}
+  .aora-cal-weekday{min-height:36px;font-size:12px}
+  .aora-cal-day{min-height:58px;border-radius:13px;font-size:15px;gap:4px}
+  .aora-cal-day:before{inset:6px 0}
+  .aora-cal-day-number{width:38px;height:38px}
+  .aora-cal-dot{width:4px;height:4px}
+  .aora-cal-sheet{margin:18px -12px -18px;padding:27px 14px calc(20px + env(safe-area-inset-bottom));border-left:0;border-right:0;border-bottom:0;border-radius:28px 28px 0 0;box-shadow:0 -14px 42px rgba(7,28,56,.1)}
+  .aora-cal-sheet-head{margin:5px 2px 14px}
+  .aora-cal-sheet-head h2{font-size:22px}
+  .aora-cal-add{width:48px;height:48px;border-radius:16px}
+  .aora-cal-summary{gap:7px}
+  .aora-cal-summary>div{grid-template-columns:1fr;grid-template-areas:"value" "label";gap:2px;padding:11px 9px;text-align:center}
+  .aora-cal-summary span{display:none}
+  .aora-cal-summary strong{font-size:14px}
+  .aora-cal-summary small{font-size:9px}
+  .aora-cal-entry{grid-template-columns:44px minmax(0,1fr) auto;gap:11px;padding:14px 13px;border-radius:16px}
+  .aora-cal-entry-icon{width:42px;height:42px;border-radius:14px}
+  .aora-cal-entry-copy strong{font-size:15px}
+  .aora-cal-entry-copy span,.aora-cal-entry-copy small{font-size:11px}
+  .aora-cal-entry-value{font-size:15px;padding-left:2px}
+  .aora-cal-entry>.u-actions{grid-column:1/-1}
+  .aora-cal-entry>.u-actions .u-btn{flex:1 1 120px}
+  .aora-cal-entry>.u-btn{grid-column:1/-1;width:100%}
+}
+
+@media(max-width:380px){
+  .aora-cal-header-actions{gap:4px}
+  .aora-cal-icon-button{width:39px;height:39px}
+  .aora-cal-month{font-size:27px}
+  .aora-cal-day{min-height:54px}
+  .aora-cal-day-number{width:36px;height:36px}
+  .aora-cal-sheet-head h2{font-size:20px}
+  .aora-cal-summary>div{padding-inline:6px}
+  .aora-cal-entry{grid-template-columns:40px minmax(0,1fr);align-items:start}
+  .aora-cal-entry-icon{width:38px;height:38px}
+  .aora-cal-entry-value{grid-column:2;justify-self:start;padding:2px 0 0}
+}
+
+@media(prefers-reduced-motion:reduce){
+  .aora-cal-icon-button,.aora-cal-day-number,.aora-cal-popover button>i,.aora-cal-popover button>i:after{transition:none}
+}

--- a/aora-v8-final/app/index.html
+++ b/aora-v8-final/app/index.html
@@ -18,6 +18,7 @@
 <link rel="stylesheet" href="compliance.css?v=814">
 <link rel="stylesheet" href="features-v2.css?v=823">
 <link rel="stylesheet" href="features-v2-fixes.css?v=825">
+<link rel="stylesheet" href="calendar-aora-redesign.css?v=826">
 </head>
 <body>
 <div id="app"><p role="status">AoraAI wird geladen …</p></div>
@@ -55,6 +56,7 @@
 <script src="modules/worker-config.js?v=823" defer></script>
 <script src="modules/unified-features.js?v=823" defer></script>
 <script src="modules/unified-runtime-fixes.js?v=825" defer></script>
+<script src="modules/calendar-aora-redesign.js?v=826" defer></script>
 <script src="modules/handlers.js?v=822" defer></script>
 <script src="modules/boot.js?v=821" defer></script>
 </body>

--- a/aora-v8-final/app/modules/calendar-aora-redesign.js
+++ b/aora-v8-final/app/modules/calendar-aora-redesign.js
@@ -1,0 +1,262 @@
+"use strict";
+
+(() => {
+  if (typeof globalThis.uCalendarPage !== "function" || typeof globalThis.uCalendarEvents !== "function") return;
+
+  const originalCalendarPage = globalThis.uCalendarPage;
+  const state = S.u.calendar;
+  state.filters = state.filters || { shifts: true, entries: true, tasks: true, leave: true };
+  state.monthMenuOpen = false;
+  state.filterMenuOpen = false;
+
+  const icon = (name) => `<span class="material-symbols-rounded" aria-hidden="true">${name}</span>`;
+  const shortDate = (date) => new Intl.DateTimeFormat("de-DE", {
+    weekday: "long",
+    day: "numeric",
+    month: "long",
+    timeZone: "UTC"
+  }).format(uDateObj(date));
+  const timeOf = (value) => {
+    const text = String(value || "");
+    if (/^\d{2}:\d{2}/.test(text)) return text.slice(0, 5);
+    const match = text.match(/T(\d{2}:\d{2})/);
+    return match ? match[1] : "–";
+  };
+  const duration = (minutes) => {
+    const value = Math.max(0, Number(minutes || 0));
+    const hours = Math.floor(value / 60);
+    const rest = value % 60;
+    return `${String(hours).padStart(2, "0")}h ${String(rest).padStart(2, "0")}m`;
+  };
+  const shiftDuration = (shift) => {
+    try { return Math.max(0, mins(shift.start, shift.end, shift.breakMinutes || 0)); }
+    catch { return 0; }
+  };
+  const filteredEvents = (date) => {
+    const events = uCalendarEvents(date);
+    return {
+      shifts: state.filters.shifts ? events.shifts : [],
+      entries: state.filters.entries ? events.entries : [],
+      tasks: state.filters.tasks ? events.tasks : [],
+      leave: state.filters.leave ? events.leave : [],
+      notes: events.notes || []
+    };
+  };
+  const sameLeave = (request, date) => {
+    if (!request) return false;
+    const id = String(request.id || request.request_id || "");
+    return uCalendarEvents(date).leave.some((item) => {
+      const itemId = String(item.id || item.request_id || "");
+      return id && itemId ? itemId === id : item === request;
+    });
+  };
+  const markerHtml = (events) => {
+    const markers = [];
+    if (events.entries.length) markers.push("time");
+    if (events.shifts.length) markers.push(events.shifts.some((item) => item.status === "open") ? "open" : "shift");
+    if (events.tasks.length) markers.push("task");
+    if (events.leave.length) markers.push("leave");
+    return markers.slice(0, 3).map((kind) => `<i class="aora-cal-dot is-${kind}"></i>`).join("");
+  };
+
+  function dayCell(date, outside = false) {
+    const events = filteredEvents(date);
+    const selected = state.selected === date;
+    const today = berlin().date === date;
+    const leave = events.leave[0];
+    const previous = leave && sameLeave(leave, uAdd(date, -1));
+    const next = leave && sameLeave(leave, uAdd(date, 1));
+    const rangeClass = leave ? ` has-range ${previous ? "range-middle" : "range-start"} ${next ? "range-continues" : "range-end"}` : "";
+    const label = `${shortDate(date)}${events.shifts.length ? `, ${events.shifts.length} Schicht` : ""}${events.tasks.length ? `, ${events.tasks.length} Aufgabe` : ""}`;
+    return `<button class="aora-cal-day${outside ? " is-outside" : ""}${selected ? " is-selected" : ""}${today ? " is-today" : ""}${rangeClass}" data-u="calendar-day" data-date="${date}" aria-label="${uHtml(label)}" aria-pressed="${selected ? "true" : "false"}">
+      <span class="aora-cal-day-number">${Number(date.slice(8, 10))}</span>
+      <span class="aora-cal-dots">${markerHtml(events)}</span>
+    </button>`;
+  }
+
+  function timeCard(entries) {
+    const minutes = entries.reduce((sum, item) => sum + Number(item.durationMinutes || 0), 0);
+    const first = entries[0];
+    const range = first ? `${timeOf(first.startTime || first.start)} – ${timeOf(first.endTime || first.end)}` : "Noch keine Zeit erfasst";
+    return `<article class="aora-cal-entry aora-cal-entry-time">
+      <div class="aora-cal-entry-icon">${icon("schedule")}</div>
+      <div class="aora-cal-entry-copy"><strong>Arbeitszeit</strong><span>${uHtml(range)}</span></div>
+      <div class="aora-cal-entry-value">${duration(minutes)}</div>
+    </article>`;
+  }
+
+  function shiftCard(shift) {
+    const statusLabel = ({
+      published: "Veröffentlicht",
+      pending_confirmation: "Bestätigung offen",
+      confirmed: "Bestätigt",
+      open: "Offene Schicht",
+      completed: "Abgeschlossen",
+      cancelled: "Abgesagt"
+    })[shift.status] || shift.status || "Geplant";
+    return `<article class="aora-cal-entry aora-cal-entry-shift">
+      <div class="aora-cal-entry-icon">${icon("calendar_today")}</div>
+      <div class="aora-cal-entry-copy"><strong>Schicht</strong><span>${uHtml(shift.start)} – ${uHtml(shift.end)} · ${uHtml(uLocationName(shift.locationId))}</span><small>${uHtml(statusLabel)} · ${Number(shift.breakMinutes || 0)} Min. Pause</small></div>
+      <div class="aora-cal-entry-value">${duration(shiftDuration(shift))}</div>
+      ${uShiftActions(shift)}
+    </article>`;
+  }
+
+  function taskCard(task) {
+    return `<article class="aora-cal-entry aora-cal-entry-task">
+      <div class="aora-cal-entry-icon">${icon("checklist")}</div>
+      <div class="aora-cal-entry-copy"><strong>${uHtml(task.task_templates?.title || "Aufgabe")}</strong><span>${uHtml(task.status || "open")} · fällig ${uHtml(timeOf(task.due_at))}</span></div>
+      ${uButton("Öffnen", "task-open", `data-id="${task.id}"`, "secondary")}
+    </article>`;
+  }
+
+  function leaveCard(request) {
+    return `<article class="aora-cal-entry aora-cal-entry-leave">
+      <div class="aora-cal-entry-icon">${icon("beach_access")}</div>
+      <div class="aora-cal-entry-copy"><strong>Abwesenheit</strong><span>${uHtml(request.type || request.payload?.type || "Urlaub")} · ${uHtml(request.status || "beantragt")}</span></div>
+    </article>`;
+  }
+
+  function daySheet(date) {
+    const events = filteredEvents(date);
+    const totalMinutes = events.entries.reduce((sum, item) => sum + Number(item.durationMinutes || 0), 0);
+    const plannedMinutes = events.shifts.reduce((sum, item) => sum + shiftDuration(item), 0);
+    const itemCount = events.entries.length + events.shifts.length + events.tasks.length + events.leave.length;
+    return `<section class="aora-cal-sheet" aria-label="Details für ${uHtml(shortDate(date))}">
+      <div class="aora-cal-handle" aria-hidden="true"></div>
+      <header class="aora-cal-sheet-head">
+        <div><h2>${uHtml(shortDate(date))}</h2><p>${itemCount} ${itemCount === 1 ? "Eintrag" : "Einträge"}</p></div>
+        <button class="aora-cal-add" data-u="availability" data-date="${date}" aria-label="Verfügbarkeit für diesen Tag setzen">${icon("add")}</button>
+      </header>
+      <div class="aora-cal-summary" aria-label="Tagesübersicht">
+        <div><span>${icon("schedule")}</span><strong>${duration(totalMinutes)}</strong><small>Erfasste Zeit</small></div>
+        <div><span>${icon("work")}</span><strong>${events.shifts.length}</strong><small>${events.shifts.length === 1 ? "Schicht" : "Schichten"}</small></div>
+        <div><span>${icon("check_circle")}</span><strong>${events.tasks.length}</strong><small>Aufgaben</small></div>
+      </div>
+      <div class="aora-cal-entry-list">
+        ${timeCard(events.entries)}
+        ${events.shifts.map(shiftCard).join("")}
+        ${events.tasks.map(taskCard).join("")}
+        ${events.leave.map(leaveCard).join("")}
+        ${!events.shifts.length && !events.tasks.length && !events.leave.length && !events.entries.length ? `<div class="aora-cal-empty">${icon("event_available")}<strong>Keine Einträge</strong><span>Für diesen Tag ist noch nichts geplant.</span></div>` : ""}
+      </div>
+      <footer class="aora-cal-day-total"><span>Tagesübersicht</span><strong>${duration(totalMinutes || plannedMinutes)}</strong><small>${totalMinutes ? "erfasst" : plannedMinutes ? "geplant" : "frei"}</small></footer>
+    </section>`;
+  }
+
+  function monthGrid() {
+    const cursor = state.cursor || uMonthStart(berlin().date);
+    const first = uMonthStart(cursor);
+    const gridStart = uStartWeek(first);
+    const days = [];
+    for (let index = 0; index < 42; index += 1) {
+      const date = uAdd(gridStart, index);
+      days.push(dayCell(date, date.slice(0, 7) !== first.slice(0, 7)));
+    }
+    return `<div class="aora-calendar-grid" role="grid" aria-label="${uHtml(uMonthLabel(first))}">
+      ${["Mo", "Di", "Mi", "Do", "Fr", "Sa", "So"].map((day) => `<div class="aora-cal-weekday" role="columnheader">${day}</div>`).join("")}
+      ${days.join("")}
+    </div>${daySheet(state.selected || berlin().date)}`;
+  }
+
+  function modeButton(mode, label, symbol) {
+    return `<button class="aora-cal-icon-button${state.mode === mode ? " is-active" : ""}" data-u="calendar-mode" data-mode="${mode}" aria-label="${label}" title="${label}">${icon(symbol)}</button>`;
+  }
+
+  function filterPopover() {
+    if (!state.filterMenuOpen) return "";
+    const options = [
+      ["shifts", "Schichten", "calendar_today"],
+      ["entries", "Arbeitszeit", "schedule"],
+      ["tasks", "Aufgaben", "checklist"],
+      ["leave", "Abwesenheit", "beach_access"]
+    ];
+    return `<div class="aora-cal-popover aora-cal-filter-popover" role="dialog" aria-label="Kalender filtern">
+      <strong>Im Kalender anzeigen</strong>
+      ${options.map(([key, label, symbol]) => `<button data-aora-calendar="filter-toggle" data-filter="${key}" aria-pressed="${state.filters[key] ? "true" : "false"}"><span>${icon(symbol)}${label}</span><i class="${state.filters[key] ? "is-on" : ""}"></i></button>`).join("")}
+    </div>`;
+  }
+
+  function monthPopover() {
+    if (!state.monthMenuOpen) return "";
+    return `<div class="aora-cal-popover aora-cal-month-popover" role="dialog" aria-label="Monat wechseln">
+      <button data-aora-calendar="month-prev">${icon("chevron_left")}Vorheriger Monat</button>
+      <button data-aora-calendar="month-today">${icon("today")}Heute</button>
+      <button data-aora-calendar="month-next">Nächster Monat${icon("chevron_right")}</button>
+    </div>`;
+  }
+
+  function calendarHeader(cursor) {
+    return `<header class="aora-cal-header">
+      <div class="aora-cal-month-wrap">
+        <button class="aora-cal-month" data-aora-calendar="month-menu" aria-expanded="${state.monthMenuOpen ? "true" : "false"}">${uHtml(uMonthLabel(cursor).replace(/\s+\d{4}$/, ""))}${icon("keyboard_arrow_down")}</button>
+        ${monthPopover()}
+      </div>
+      <div class="aora-cal-header-actions">
+        ${modeButton("month", "Monatsansicht", "calendar_month")}
+        ${modeButton("list", "Listenansicht", "view_list")}
+        <div class="aora-cal-filter-wrap"><button class="aora-cal-icon-button${state.filterMenuOpen ? " is-active" : ""}" data-aora-calendar="filter-menu" aria-label="Kalender filtern" aria-expanded="${state.filterMenuOpen ? "true" : "false"}">${icon("filter_alt")}</button>${filterPopover()}</div>
+      </div>
+    </header>`;
+  }
+
+  globalThis.uCalendarPage = function aoraCalendarPage() {
+    queueMicrotask(() => uEnsureCalendar());
+    if (state.loading && !state.data) return uBusy();
+    if (state.error) return `<div class="u-warning-panel">${uHtml(state.error)} ${uButton("Erneut laden", "calendar-reload")}</div>`;
+    const cursor = state.cursor || uMonthStart(berlin().date);
+    const body = state.mode === "month" ? monthGrid() : state.mode === "week" ? uRenderWeek() : uRenderList();
+    return `<section class="aora-calendar-page" data-calendar-mode="${state.mode}">${calendarHeader(cursor)}<div class="aora-cal-body">${body}</div></section>`;
+  };
+
+  function moveMonth(offset) {
+    const date = uDateObj(uMonthStart(state.cursor || berlin().date));
+    date.setUTCMonth(date.getUTCMonth() + offset);
+    state.cursor = uMonthStart(uDate(date));
+    state.selected = state.cursor;
+    state.monthMenuOpen = false;
+    render();
+    queueMicrotask(() => uEnsureCalendar(true));
+  }
+
+  document.addEventListener("click", (event) => {
+    const control = event.target.closest("[data-aora-calendar]");
+    if (!control) {
+      if ((state.monthMenuOpen || state.filterMenuOpen) && !event.target.closest(".aora-cal-popover")) {
+        state.monthMenuOpen = false;
+        state.filterMenuOpen = false;
+        render();
+      }
+      return;
+    }
+    const action = control.dataset.aoraCalendar;
+    if (action === "month-menu") {
+      state.monthMenuOpen = !state.monthMenuOpen;
+      state.filterMenuOpen = false;
+      render();
+    } else if (action === "filter-menu") {
+      state.filterMenuOpen = !state.filterMenuOpen;
+      state.monthMenuOpen = false;
+      render();
+    } else if (action === "filter-toggle") {
+      const key = control.dataset.filter;
+      if (Object.prototype.hasOwnProperty.call(state.filters, key)) state.filters[key] = !state.filters[key];
+      render();
+    } else if (action === "month-prev") moveMonth(-1);
+    else if (action === "month-next") moveMonth(1);
+    else if (action === "month-today") {
+      state.cursor = uMonthStart(berlin().date);
+      state.selected = berlin().date;
+      state.monthMenuOpen = false;
+      render();
+      queueMicrotask(() => uEnsureCalendar(true));
+    }
+  });
+
+  globalThis.AoraCalendarRedesign = {
+    version: "826",
+    originalCalendarPage,
+    duration,
+    filteredEvents
+  };
+})();

--- a/aora-v8-final/tests/aora-mobile-layout.spec.mjs
+++ b/aora-v8-final/tests/aora-mobile-layout.spec.mjs
@@ -62,6 +62,42 @@ test("390px mobile layouts keep controls aligned and overflow contained",async({
   const employeeContext=await browser.newContext(mobile);
   const employee=await employeeContext.newPage();
   await login(employee,"employee",required("AORA_EMPLOYEE_EMAIL"),required("AORA_EMPLOYEE_PASSWORD"));
+
+  await employee.evaluate(()=>{S.employeeView="calendar";render()});
+  await expect(employee.locator(".aora-calendar-page")).toBeVisible({timeout:30000});
+  await expect(employee.locator(".aora-calendar-grid")).toBeVisible();
+  await expect(employee.locator(".aora-cal-sheet")).toBeVisible();
+  await expect(employee.locator(".aora-cal-day")).toHaveCount(42);
+  await expect(employee.locator(".aora-cal-day.is-selected")).toHaveCount(1);
+  await expect(employee.locator(".aora-cal-header-actions .aora-cal-icon-button")).toHaveCount(3);
+  await assertNoPageOverflow(employee);
+  const calendarLayout=await employee.locator(".aora-calendar-page").evaluate(element=>{
+    const pageRect=element.getBoundingClientRect();
+    const grid=element.querySelector(".aora-calendar-grid").getBoundingClientRect();
+    const sheet=element.querySelector(".aora-cal-sheet").getBoundingClientRect();
+    return{
+      viewport:window.innerWidth,
+      pageLeft:pageRect.left,
+      pageRight:pageRect.right,
+      gridLeft:grid.left,
+      gridRight:grid.right,
+      sheetLeft:sheet.left,
+      sheetRight:sheet.right
+    };
+  });
+  expect(calendarLayout.pageLeft).toBeGreaterThanOrEqual(-1);
+  expect(calendarLayout.pageRight).toBeLessThanOrEqual(calendarLayout.viewport+1);
+  expect(calendarLayout.gridLeft).toBeGreaterThanOrEqual(-1);
+  expect(calendarLayout.gridRight).toBeLessThanOrEqual(calendarLayout.viewport+1);
+  expect(calendarLayout.sheetLeft).toBeGreaterThanOrEqual(-1);
+  expect(calendarLayout.sheetRight).toBeLessThanOrEqual(calendarLayout.viewport+1);
+
+  await employee.locator('[data-aora-calendar="filter-menu"]').click();
+  await expect(employee.locator(".aora-cal-filter-popover")).toBeVisible();
+  await employee.locator('[data-aora-calendar="filter-toggle"][data-filter="tasks"]').click();
+  await expect(employee.locator('[data-aora-calendar="filter-toggle"][data-filter="tasks"]')).toHaveAttribute("aria-pressed","false");
+  await employee.locator('[data-aora-calendar="filter-toggle"][data-filter="tasks"]').click();
+
   await employee.evaluate(()=>{S.employeeView="tasks";render()});
   await expect(employee.getByText("Meine Aufgaben")).toBeVisible({timeout:30000});
   await assertNoPageOverflow(employee);

--- a/aora-v8-final/tests/aora-unified-release.spec.mjs
+++ b/aora-v8-final/tests/aora-unified-release.spec.mjs
@@ -57,8 +57,10 @@ test("unified Calendar, Schedule, Tasks and clock-out gate pass in the visible p
   const employee=await employeeContext.newPage();
   await login(employee,"employee",required("AORA_EMPLOYEE_EMAIL"),required("AORA_EMPLOYEE_PASSWORD"));
   await employee.locator('.employee-bottom [data-a="employee-view"][data-view="calendar"]').click();
-  await expect(employee.getByText("Dienstplan & Aufgaben")).toBeVisible({timeout:30000});
-  await expect(employee.getByText("12:00–14:00").first()).toBeVisible();
+  await expect(employee.locator(".aora-calendar-page")).toBeVisible({timeout:30000});
+  await expect(employee.locator(".aora-calendar-grid")).toBeVisible();
+  await expect(employee.locator(".aora-cal-sheet")).toBeVisible();
+  await expect(employee.locator(".aora-cal-entry-shift").filter({hasText:/12:00\s*[–-]\s*14:00/}).first()).toBeVisible({timeout:30000});
   await employee.locator('.employee-bottom [data-u="employee-tasks"]').click();
   await expect(employee.getByText("Meine Aufgaben")).toBeVisible({timeout:30000});
   await expect(employee.getByText("Release Opening Checklist").first()).toBeVisible();

--- a/aora-v8-final/tests/unified-feature-source.mjs
+++ b/aora-v8-final/tests/unified-feature-source.mjs
@@ -3,9 +3,11 @@ import { resolve } from "node:path";
 
 const root=resolve(import.meta.dirname,"..");
 const read=path=>readFile(resolve(root,path),"utf8");
-const [index,features,worker,serviceWorker,domainApi]=await Promise.all([
+const [index,features,calendarRedesign,calendarStyles,worker,serviceWorker,domainApi]=await Promise.all([
   read("app/index.html"),
   read("app/modules/unified-features.js"),
+  read("app/modules/calendar-aora-redesign.js"),
+  read("app/calendar-aora-redesign.css"),
   read("app/modules/worker-config.js"),
   read("app/sw.js"),
   read("supabase/functions/aora-v8-domain-api/index.ts")
@@ -14,7 +16,9 @@ const [index,features,worker,serviceWorker,domainApi]=await Promise.all([
 const requiredIndexMarkers=[
   "features-v2.css?v=823",
   "modules/worker-config.js?v=823",
-  "modules/unified-features.js?v=823"
+  "modules/unified-features.js?v=823",
+  "calendar-aora-redesign.css?v=826",
+  "modules/calendar-aora-redesign.js?v=826"
 ];
 for(const marker of requiredIndexMarkers){
   if(!index.includes(marker))throw new Error(`Unified feature asset is not loaded by index.html: ${marker}`);
@@ -24,6 +28,9 @@ if(index.indexOf("modules/worker-config.js?v=823")>index.indexOf("modules/unifie
 }
 if(index.indexOf("modules/unified-features.js?v=823")>index.indexOf("modules/handlers.js?v=822")){
   throw new Error("Unified features must wrap views before handler and boot initialization.");
+}
+if(index.indexOf("modules/calendar-aora-redesign.js?v=826")<index.indexOf("modules/unified-features.js?v=823")||index.indexOf("modules/calendar-aora-redesign.js?v=826")>index.indexOf("modules/handlers.js?v=822")){
+  throw new Error("The Aora calendar redesign must load after unified features and before handlers.");
 }
 for(const marker of [
   'CFG.domainFunction=CFG.domainFunction||"aora-v8-domain-api"',
@@ -36,6 +43,25 @@ for(const marker of [
 ]){
   if(!features.includes(marker))throw new Error(`Missing unified feature runtime marker: ${marker}`);
 }
+for(const marker of [
+  'globalThis.uCalendarPage = function aoraCalendarPage',
+  'aora-calendar-grid',
+  'aora-cal-sheet',
+  'data-u="calendar-day"',
+  'data-aora-calendar="filter-toggle"',
+  'version: "826"'
+]){
+  if(!calendarRedesign.includes(marker))throw new Error(`Missing Aora calendar redesign marker: ${marker}`);
+}
+for(const marker of [
+  '.aora-calendar-page',
+  '.aora-calendar-grid',
+  '.aora-cal-sheet',
+  '@media(max-width:700px)',
+  '.aora-cal-day.is-selected'
+]){
+  if(!calendarStyles.includes(marker))throw new Error(`Missing Aora calendar style marker: ${marker}`);
+}
 for(const marker of ['case"clockoutGate"','case"managerOverride"','case"submitTask"']){
   if(!domainApi.includes(marker))throw new Error(`Missing unified domain gate marker: ${marker}`);
 }
@@ -45,4 +71,4 @@ for(const marker of ["globalThis.ensureWorker","AORA_CONFIG","supabaseUrl:CFG.ur
 for(const forbidden of ["xqgkawskftzurbujrpex","lxpmgnllgqdulfjxbdau"]){
   if(serviceWorker.includes(forbidden))throw new Error(`Service worker contains a hard-coded project reference: ${forbidden}`);
 }
-console.log("Unified workforce source gate passed: canonical entry point, feature runtime, domain gates and environment-safe service worker are wired.");
+console.log("Unified workforce source gate passed: canonical entry point, Aora calendar redesign, feature runtime, domain gates and environment-safe service worker are wired.");


### PR DESCRIPTION
## Scope
- redesign only the Employee Calendar page in the existing Aora design system
- keep the current calendar API, shifts, time entries, tasks, leave, open-shift and confirmation actions
- add branded month grid, selected-day sheet, filters and compact month navigation
- preserve the existing Employee header and bottom navigation

## Mobile behavior
- 42-day month grid at 390px without horizontal overflow
- selected date, today and leave ranges have distinct accessible states
- daily detail sheet is edge-aligned and mobile-safe
- task and shift actions remain available

## Tests
- source/build gate for the new assets and load order
- 390px Playwright assertions for grid, selected day, filters, detail sheet and overflow
- existing four-role, invitation, offline Kiosk and load gates remain unchanged

## Rollback
- remove the two version 826 assets from index.html; no database or backend changes are included.