### PR TITLE
Fix manager invitation activation and error rendering

### DIFF
--- a/aora-v8-final/app/index.html
+++ b/aora-v8-final/app/index.html
@@ -24,7 +24,7 @@
 <div id="app"><p role="status">AoraAI wird geladen …</p></div>
 <div id="toast-root" aria-live="assertive"></div>
 <script src="runtime-config.js" defer></script>
-<script src="modules/utils.js?v=804" defer></script>
+<script src="modules/utils.js?v=805" defer></script>
 <script src="modules/config.js?v=821" defer></script>
 <script src="modules/date-hardening.js?v=808" defer></script>
 <script src="modules/logo.js?v=804" defer></script>

--- a/aora-v8-final/app/modules/utils.js
+++ b/aora-v8-final/app/modules/utils.js
@@ -11,6 +11,26 @@ function rolePath(role){
 }
 function esc(v){return String(v??"").replace(/[&<>"']/g,c=>({"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;"})[c])}
 function initials(n){return String(n||"AO").trim().split(/\s+/).slice(0,2).map(x=>x[0]).join("").toUpperCase()}
-function toast(msg,type=""){const n=document.createElement("div");n.className=`toast ${type}`;n.textContent=msg;toasts.appendChild(n);setTimeout(()=>n.remove(),3800)}
+function messageText(value,depth=0){
+  if(depth>3)return"Unbekannter Fehler.";
+  if(value instanceof Error)return value.message||"Unbekannter Fehler.";
+  if(typeof value==="string")return value.trim()||"Unbekannter Fehler.";
+  if(Array.isArray(value)){
+    const messages=value.map(item=>messageText(item,depth+1)).filter(Boolean);
+    return messages.join("\n")||"Unbekannter Fehler.";
+  }
+  if(value&&typeof value==="object"){
+    for(const key of ["message","error","detail","details","description"]){
+      if(value[key]===undefined||value[key]===null)continue;
+      const message=messageText(value[key],depth+1);
+      if(message&&message!=="Unbekannter Fehler.")return message;
+    }
+    if(value.code)return`Fehler ${String(value.code)}`;
+    return"Unbekannter Fehler.";
+  }
+  if(value===undefined||value===null||value==="")return"Unbekannter Fehler.";
+  return String(value);
+}
+function toast(msg,type=""){const n=document.createElement("div");n.className=`toast ${type}`;n.textContent=messageText(msg);toasts.appendChild(n);setTimeout(()=>n.remove(),3800)}
 function berlin(){const p=new Intl.DateTimeFormat("sv-SE",{timeZone:CFG.tz,year:"numeric",month:"2-digit",day:"2-digit",hour:"2-digit",minute:"2-digit",second:"2-digit",hour12:false}).formatToParts(new Date()).reduce((a,x)=>(x.type!=="literal"&&(a[x.type]=x.value),a),{});return{date:`${p.year}-${p.month}-${p.day}`,time:`${p.hour}:${p.minute}`,seconds:p.second}}
 function fd(v,opt={}){if(!v)return"–";const d=v instanceof Date?v:new Date(`${v}T12:00:00`);return new Intl.DateTimeFormat("de-DE",{timeZone:CFG.tz,weekday:opt.weekday?"long":undefined,day:"2-digit",month:opt.long?"long":"2-digit",year:opt.year===false?undefined:"numeric"}).format(d)}function startWeek(v=new Date()){const d=new Date(v),day=d.getDay()||7;d.setDate(d.getDate()-day+1);d.setHours(12,0,0,0);return d.toISOString().slice(0,10)}function addDays(s,n){const d=new Date(`${s}T12:00:00`);d.setDate(d.getDate()+n);return d.toISOString().slice(0,10)}function mins(a,b,br=0){if(!a||!b)return 0;const[ah,am]=a.split(":").map(Number),[bh,bm]=b.split(":").map(Number);let m=bh*60+bm-ah*60-am;if(m<0)m+=1440;return Math.max(0,m-Number(br||0))}function fm(m){m=Math.round(Number(m||0));const sign=m<0?"−":"";m=Math.abs(m);return`${sign}${String(Math.floor(m/60)).padStart(2,"0")}h ${String(m%60).padStart(2,"0")}m`}function emp(id){return S.state?.employees?.find(x=>x.id===id)||S.directory?.employees?.find(x=>x.id===id)}function loc(id){return S.state?.locations?.find(x=>x.id===id)||S.directory?.locations?.find(x=>x.id===id)}function live(id){return S.state?.timeEntries?.find(x=>x.employeeId===id&&["live","paused"].includes(x.status))}

--- a/aora-v8-final/supabase/migrations/202608010015_fix_manager_invitation_activation_fk.sql
+++ b/aora-v8-final/supabase/migrations/202608010015_fix_manager_invitation_activation_fk.sql
@@ -1,0 +1,172 @@
+begin;
+
+insert into public.admins (organization_id, id, name, role, payload)
+select
+  ws.organization_id,
+  admin_item ->> 'id',
+  admin_item ->> 'name',
+  coalesce(nullif(admin_item ->> 'role', ''), nullif(admin_item ->> 'scope', ''), 'manager'),
+  admin_item
+from public.workspace_snapshots ws
+cross join lateral jsonb_array_elements(coalesce(ws.state -> 'admins', '[]'::jsonb)) admin_item
+where nullif(admin_item ->> 'id', '') is not null
+on conflict (organization_id, id) do update set
+  name = excluded.name,
+  role = excluded.role,
+  payload = excluded.payload;
+
+create or replace function public.aora_activate_invitation_atomic(
+  p_organization_id uuid,
+  p_expected_revision bigint,
+  p_invitation_id text,
+  p_token_hash text,
+  p_subject_role text,
+  p_subject_id text,
+  p_email text,
+  p_salt text,
+  p_password_hash text,
+  p_iterations integer,
+  p_state jsonb,
+  p_session_token_hash text,
+  p_session_location_id text,
+  p_session_ttl_seconds integer default 43200
+) returns table(next_revision bigint, session_expires_at timestamptz)
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_revision bigint := p_expected_revision + 1;
+  v_now timestamptz := clock_timestamp();
+  v_expires timestamptz := v_now + make_interval(secs => greatest(300, least(p_session_ttl_seconds, 86400)));
+  v_admin jsonb;
+  affected integer;
+begin
+  if p_subject_role not in ('admin', 'employee')
+     or p_email is null
+     or p_iterations < 210000
+     or p_state is null
+     or p_session_token_hash !~ '^[0-9a-f]{64}$' then
+    raise exception 'invalid invitation activation parameters';
+  end if;
+
+  perform 1
+  from public.aora_v8_final_invitation_tokens
+  where organization_id = p_organization_id
+    and invitation_id = p_invitation_id
+    and trim(token_hash) = lower(p_token_hash)
+    and used_at is null
+    and revoked_at is null
+    and expires_at > v_now
+  for update;
+  if not found then
+    raise exception 'invitation_invalid';
+  end if;
+
+  update public.workspace_snapshots
+  set state = p_state,
+      revision = v_revision,
+      updated_at = v_now
+  where organization_id = p_organization_id
+    and revision = p_expected_revision;
+  get diagnostics affected = row_count;
+  if affected <> 1 then
+    raise exception 'revision_conflict';
+  end if;
+
+  insert into public.aora_v8_final_credentials (
+    organization_id, subject_role, subject_id, email, salt, password_hash,
+    iterations, active, created_at, updated_at
+  ) values (
+    p_organization_id, p_subject_role, p_subject_id, lower(p_email), p_salt,
+    p_password_hash, p_iterations, true, v_now, v_now
+  )
+  on conflict (organization_id, subject_role, subject_id) do update set
+    email = excluded.email,
+    salt = excluded.salt,
+    password_hash = excluded.password_hash,
+    iterations = excluded.iterations,
+    active = true,
+    updated_at = v_now;
+
+  update public.aora_v8_final_invitation_tokens
+  set used_at = v_now,
+      updated_at = v_now
+  where organization_id = p_organization_id
+    and invitation_id = p_invitation_id;
+
+  if p_subject_role = 'admin' then
+    select admin_item
+    into v_admin
+    from jsonb_array_elements(coalesce(p_state -> 'admins', '[]'::jsonb)) admin_item
+    where admin_item ->> 'id' = p_subject_id
+    limit 1;
+
+    if v_admin is null then
+      raise exception 'admin_projection_missing';
+    end if;
+
+    insert into public.admins (organization_id, id, name, role, payload)
+    values (
+      p_organization_id,
+      p_subject_id,
+      v_admin ->> 'name',
+      coalesce(nullif(v_admin ->> 'role', ''), nullif(v_admin ->> 'scope', ''), 'manager'),
+      v_admin
+    )
+    on conflict (organization_id, id) do update set
+      name = excluded.name,
+      role = excluded.role,
+      payload = excluded.payload;
+
+    delete from public.manager_location_access
+    where organization_id = p_organization_id
+      and manager_id = p_subject_id;
+
+    if coalesce(v_admin ->> 'scope', 'manager') = 'manager' then
+      insert into public.manager_location_access (
+        organization_id, manager_id, location_id, created_at
+      )
+      select
+        p_organization_id,
+        p_subject_id,
+        location_value,
+        v_now
+      from jsonb_array_elements_text(
+        case
+          when jsonb_typeof(v_admin -> 'locationIds') = 'array' then v_admin -> 'locationIds'
+          when nullif(v_admin ->> 'locationId', '') is not null then jsonb_build_array(v_admin ->> 'locationId')
+          else '[]'::jsonb
+        end
+      ) location_value
+      join public.locations location_row
+        on location_row.organization_id = p_organization_id
+       and location_row.id = location_value
+      on conflict (organization_id, manager_id, location_id) do nothing;
+    end if;
+  end if;
+
+  insert into public.app_sessions (
+    organization_id, role, subject_id, location_id, token_hash,
+    expires_at, last_seen_at, created_at
+  ) values (
+    p_organization_id, p_subject_role, p_subject_id, p_session_location_id,
+    decode(p_session_token_hash, 'hex'), v_expires, v_now, v_now
+  );
+
+  insert into public.workspace_changes (organization_id, revision, changed_at)
+  values (p_organization_id, v_revision, v_now)
+  on conflict (organization_id) do update set
+    revision = excluded.revision,
+    changed_at = excluded.changed_at;
+
+  next_revision := v_revision;
+  session_expires_at := v_expires;
+  return next;
+end;
+$$;
+
+revoke all on function public.aora_activate_invitation_atomic(uuid,bigint,text,text,text,text,text,text,text,integer,jsonb,text,text,integer) from public, anon, authenticated;
+grant execute on function public.aora_activate_invitation_atomic(uuid,bigint,text,text,text,text,text,text,text,integer,jsonb,text,text,integer) to service_role;
+
+commit;


### PR DESCRIPTION
This fixes the production manager invitation failure without changing unrelated workflows.

- synchronizes snapshot-only managers into the normalized `admins` table before location access is written
- updates the atomic invitation activation function to preserve foreign-key ordering
- normalizes structured frontend errors so objects never render as `[object Object]`
- bumps the cached `utils.js` version

Validation performed:
- production migration applied successfully
- pending invitation remains untouched and valid
- full activation path executed in a forced-rollback dry run
- assertions passed for revision, credential, normalized admin, manager location access, invitation consumption, and session creation
- frontend JavaScript syntax and structured-error cases passed locally