### PR TITLE
Integrate employee shift preferences into native Aora scheduling

### DIFF
--- a/aora-v8-final/app/index.html
+++ b/aora-v8-final/app/index.html
@@ -63,6 +63,7 @@
 <script src="modules/calendar-aora-redesign.js?v=826" defer></script>
 <script src="modules/production-experience.js?v=827" defer></script>
 <script src="modules/production-experience-fixes.js?v=827" defer></script>
+<script src="modules/shift-preferences.js?v=830" defer></script>
 <script src="modules/handlers.js?v=822" defer></script>
 <script src="modules/boot.js?v=821" defer></script>
 </body>

--- a/aora-v8-final/app/modules/shift-preferences.js
+++ b/aora-v8-final/app/modules/shift-preferences.js
@@ -1,0 +1,281 @@
+"use strict";
+
+(() => {
+  const FUNCTION_NAME = "aora-v8-shift-preferences";
+  const originalEmployeeCalendar = typeof globalThis.uCalendarPage === "function" ? globalThis.uCalendarPage : null;
+  const originalAdminView = typeof globalThis.adminView === "function" ? globalThis.adminView : null;
+  const currentDate = () => typeof berlin === "function" ? berlin().date : new Date().toISOString().slice(0, 10);
+  const employeeId = () => String(S.session?.subjectId || S.session?.employeeId || "");
+  const icon = (name) => `<span class="material-symbols-rounded" aria-hidden="true">${name}</span>`;
+  const statusLabel = (status) => ({ pending: "Offen", accepted: "Übernommen", rejected: "Abgelehnt", cancelled: "Zurückgezogen" })[status] || status || "Offen";
+  const minutes = (start, end, breakMinutes = 0) => {
+    try { return mins(start, end, breakMinutes); }
+    catch {
+      const [sh, sm] = String(start || "00:00").split(":").map(Number);
+      const [eh, em] = String(end || "00:00").split(":").map(Number);
+      return Math.max(0, eh * 60 + em - sh * 60 - sm - Number(breakMinutes || 0));
+    }
+  };
+  const duration = (value) => typeof fm === "function"
+    ? fm(value)
+    : `${Math.floor(Number(value || 0) / 60)}:${String(Number(value || 0) % 60).padStart(2, "0")} Std.`;
+
+  function normalizePreference(item) {
+    const payload = item?.payload && typeof item.payload === "object" ? item.payload : item || {};
+    return {
+      id: String(item?.id || payload.id || ""),
+      shiftId: item?.shiftId ?? item?.shift_id ?? payload.shiftId ?? null,
+      employeeId: String(item?.employeeId ?? item?.employee_id ?? payload.employeeId ?? ""),
+      locationId: String(item?.locationId ?? item?.location_id ?? payload.locationId ?? ""),
+      requestType: String(item?.requestType ?? item?.request_type ?? payload.requestType ?? ""),
+      date: String(item?.date ?? payload.date ?? ""),
+      start: String(item?.start ?? payload.start ?? "").slice(0, 5),
+      end: String(item?.end ?? payload.end ?? "").slice(0, 5),
+      breakMinutes: Number(item?.breakMinutes ?? payload.breakMinutes ?? 0),
+      note: String(item?.note ?? payload.note ?? ""),
+      status: String(item?.status ?? payload.status ?? "pending"),
+      reason: String(item?.reason ?? payload.reason ?? ""),
+      createdAt: item?.createdAt ?? item?.created_at ?? payload.createdAt ?? null
+    };
+  }
+
+  function sourceRows() {
+    if (["manager", "owner"].includes(S.accessRole) && Array.isArray(S.u?.schedule?.data?.shiftRequests)) {
+      return S.u.schedule.data.shiftRequests;
+    }
+    return Array.isArray(S.state?.shiftRequests) ? S.state.shiftRequests : [];
+  }
+
+  function preferences() {
+    return sourceRows().map(normalizePreference).filter((item) => item.id && item.requestType === "shift_preference");
+  }
+
+  function ownPreferences(date) {
+    const id = employeeId();
+    return preferences()
+      .filter((item) => item.employeeId === id && item.date === date)
+      .sort((a, b) => `${a.start}${a.createdAt || ""}`.localeCompare(`${b.start}${b.createdAt || ""}`));
+  }
+
+  function managerPreferences() {
+    return preferences()
+      .filter((item) => item.status === "pending" && item.locationId === String(S.locationId || ""))
+      .sort((a, b) => `${a.date}${a.start}`.localeCompare(`${b.date}${b.start}`));
+  }
+
+  async function preferenceRequest(action, payload = {}) {
+    return request(FUNCTION_NAME, {
+      action,
+      token: S.session?.token,
+      idempotencyKey: crypto.randomUUID(),
+      ...payload
+    });
+  }
+
+  function employeeCard(item) {
+    const pending = item.status === "pending";
+    return `<article class="aora-cal-entry aora-cal-entry-shift" data-sp-preference-card="${esc(item.id)}">
+      <div class="aora-cal-entry-icon">${icon("event_upcoming")}</div>
+      <div class="aora-cal-entry-copy"><strong>Schichtwunsch</strong><span>${esc(item.start)} – ${esc(item.end)} · ${esc(loc(item.locationId)?.name || "Standort")}</span><small>${esc(statusLabel(item.status))}${item.note ? ` · ${esc(item.note)}` : ""}</small></div>
+      <div class="aora-cal-entry-value">${duration(minutes(item.start, item.end, item.breakMinutes))}</div>
+      ${pending ? `<div class="u-actions"><button class="u-btn secondary" data-sp-action="cancel" data-id="${esc(item.id)}">Zurückziehen</button></div>` : ""}
+    </article>`;
+  }
+
+  function decorateEmployeeCalendar() {
+    if (S.accessRole !== "employee" || S.employeeView !== "calendar") return;
+    const selected = S.u.calendar?.selected || currentDate();
+    const sheetHead = document.querySelector(".aora-cal-sheet-head");
+    const nativeAvailability = sheetHead?.querySelector('[data-u="availability"]');
+    if (nativeAvailability && !sheetHead.querySelector('[data-sp-action="create"]')) {
+      let actions = nativeAvailability.parentElement?.classList.contains("aora-cal-header-actions") ? nativeAvailability.parentElement : null;
+      if (!actions) {
+        actions = document.createElement("div");
+        actions.className = "aora-cal-header-actions";
+        nativeAvailability.before(actions);
+        actions.append(nativeAvailability);
+      }
+      nativeAvailability.title = "Verfügbarkeit festlegen";
+      const trigger = document.createElement("button");
+      trigger.className = "aora-cal-add";
+      trigger.type = "button";
+      trigger.dataset.spAction = "create";
+      trigger.dataset.date = selected;
+      trigger.setAttribute("aria-label", "Schichtwunsch für diesen Tag abgeben");
+      trigger.title = "Schicht wünschen";
+      trigger.innerHTML = icon("event_upcoming");
+      actions.append(trigger);
+    }
+
+    const list = document.querySelector(".aora-cal-entry-list");
+    if (!list) return;
+    list.querySelectorAll("[data-sp-preference-card]").forEach((node) => node.remove());
+    const cards = ownPreferences(selected).map(employeeCard).join("");
+    if (cards) list.insertAdjacentHTML("afterbegin", cards);
+  }
+
+  function managerItem(item) {
+    const employee = emp(item.employeeId);
+    return `<article class="u-item-card" data-sp-preference-manager="${esc(item.id)}">
+      <h3>${esc(employee?.name || "Mitarbeiter")}</h3>
+      <p>${esc(fd(item.date, { weekday: true }))} · ${esc(item.start)}–${esc(item.end)} · ${Number(item.breakMinutes || 0)} Min. Pause${item.note ? ` · ${esc(item.note)}` : ""}</p>
+      <div class="u-actions"><button class="u-btn secondary" data-sp-action="review" data-id="${esc(item.id)}">Prüfen</button></div>
+    </article>`;
+  }
+
+  function managerBoardPanel() {
+    const rows = managerPreferences();
+    return `<section class="u-day-detail" data-sp-preferences-panel><h2>Schichtwünsche</h2>${rows.map(managerItem).join("") || (typeof uEmpty === "function" ? uEmpty("Keine offenen Schichtwünsche für diesen Standort.") : '<div class="empty">Keine offenen Schichtwünsche für diesen Standort.</div>')}</section>`;
+  }
+
+  function legacyManagerPanel() {
+    const rows = managerPreferences();
+    return `<article class="dashboard-card" data-sp-preferences-panel>
+      <div class="dashboard-card-head"><h2>Schichtwünsche <small>${rows.length}</small></h2><span class="status-chip${rows.length ? " black" : ""}">${rows.length ? "Prüfung offen" : "Aktuell"}</span></div>
+      <div class="dashboard-body">${rows.map((item) => {
+        const employee = emp(item.employeeId);
+        return `<div class="duty-row"><div class="initial-bar">${esc(employee?.initials || initials(employee?.name || "Mitarbeiter"))}</div><div class="row-copy"><strong>${esc(employee?.name || "Mitarbeiter")}</strong><small>${esc(fd(item.date, { weekday: true }))} · ${esc(item.start)}–${esc(item.end)} · ${Number(item.breakMinutes || 0)} Min. Pause${item.note ? ` · ${esc(item.note)}` : ""}</small></div><span class="status-chip">Wunsch</span><div class="leave-actions"><button class="btn outline" data-sp-action="review" data-id="${esc(item.id)}">Prüfen</button></div></div>`;
+      }).join("") || '<div class="empty">Keine offenen Schichtwünsche für diesen Standort.</div>'}</div>
+    </article>`;
+  }
+
+  function decorateManagerSchedule() {
+    if (!["manager", "owner"].includes(S.accessRole) || S.adminView !== "schedule") return;
+    const ids = new Set(managerPreferences().map((item) => item.id));
+    document.querySelectorAll('[data-u="request-decision"][data-id]').forEach((button) => {
+      if (ids.has(String(button.dataset.id || ""))) button.closest(".u-item-card")?.remove();
+    });
+    const shell = document.querySelector(".u-schedule-shell");
+    if (!shell) return;
+    shell.querySelector("[data-sp-preferences-panel]")?.remove();
+    shell.insertAdjacentHTML("beforeend", managerBoardPanel());
+  }
+
+  function openCreateModal(date) {
+    const currentEmployee = S.state?.employees?.find((item) => String(item.id) === employeeId());
+    const locationId = currentEmployee?.primaryLocationId || currentEmployee?.locationId || S.session?.locationId;
+    const dialog = modal(`${modalHeader("Kalender", "Schichtwunsch abgeben")}<form class="form-grid">
+      <div class="field"><label>Datum</label><input class="input" name="date" type="date" min="${currentDate()}" value="${esc(date || currentDate())}" required></div>
+      <div class="field"><label>Standort</label><input class="input" value="${esc(loc(locationId)?.name || "Hauptstandort")}" disabled></div>
+      <div class="field"><label>Beginn</label><input class="input" name="start" type="time" value="09:00" required></div>
+      <div class="field"><label>Ende</label><input class="input" name="end" type="time" value="17:00" required></div>
+      <div class="field full"><label>Pause</label><input class="input" name="breakMinutes" type="number" min="0" max="180" step="5" value="30" required></div>
+      <div class="field full"><label>Notiz (optional)</label><textarea class="textarea" name="note" maxlength="240" placeholder="z. B. Frühschicht bevorzugt"></textarea></div>
+      <div class="field full exception-summary"><strong>Noch keine feste Schicht</strong><p>Der Wunsch wird erst nach Bestätigung durch deinen Manager in den Dienstplan übernommen.</p></div>
+      <div class="field full actions"><button type="button" class="btn outline" data-a="close">Abbrechen</button><button class="btn" type="submit">Wunsch senden</button></div>
+    </form>`);
+    dialog.querySelector("form")?.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      if (S.busy) return;
+      S.busy = true;
+      const submit = event.currentTarget.querySelector('button[type="submit"]');
+      if (submit) submit.disabled = true;
+      try {
+        const values = new FormData(event.currentTarget);
+        const data = await preferenceRequest("create", { preference: {
+          date: String(values.get("date") || ""),
+          start: String(values.get("start") || ""),
+          end: String(values.get("end") || ""),
+          breakMinutes: Number(values.get("breakMinutes") || 0),
+          note: String(values.get("note") || "").trim()
+        } });
+        dialog.remove();
+        await refresh(data, "Schichtwunsch wurde gesendet.");
+      } catch (error) {
+        if (submit) submit.disabled = false;
+        toast(error?.message || "Schichtwunsch konnte nicht gesendet werden.", "error");
+      } finally { S.busy = false; }
+    });
+  }
+
+  function openReviewModal(id) {
+    const item = preferences().find((candidate) => candidate.id === id);
+    if (!item) return toast("Schichtwunsch wurde nicht gefunden.", "error");
+    const employee = emp(item.employeeId);
+    const dialog = modal(`${modalHeader("Dienstplan", "Schichtwunsch prüfen")}<form class="form-grid">
+      <div class="field full exception-summary"><strong>${esc(employee?.name || "Mitarbeiter")}</strong><p>${esc(fd(item.date, { weekday: true }))} · ${esc(loc(item.locationId)?.name || "Standort")}${item.note ? ` · ${esc(item.note)}` : ""}</p></div>
+      <div class="field"><label>Beginn</label><input class="input" name="start" type="time" value="${esc(item.start)}" required></div>
+      <div class="field"><label>Ende</label><input class="input" name="end" type="time" value="${esc(item.end)}" required></div>
+      <div class="field full"><label>Pause</label><input class="input" name="breakMinutes" type="number" min="0" max="180" step="5" value="${Number(item.breakMinutes || 0)}" required></div>
+      <div class="field full"><label>Notiz an Mitarbeiter (optional)</label><textarea class="textarea" name="reason" maxlength="240"></textarea></div>
+      <div class="field full actions"><button type="button" class="btn light" data-sp-action="reject" data-id="${esc(item.id)}">Ablehnen</button><button type="button" class="btn outline" data-a="close">Abbrechen</button><button class="btn" type="submit">In Dienstplan übernehmen</button></div>
+    </form>`);
+    const form = dialog.querySelector("form");
+    form?.addEventListener("submit", async (event) => { event.preventDefault(); await decide(dialog, item, event.currentTarget, "accepted"); });
+    dialog.querySelector('[data-sp-action="reject"]')?.addEventListener("click", async () => { await decide(dialog, item, form, "rejected"); });
+  }
+
+  async function decide(dialog, item, form, decision) {
+    if (S.busy || !form) return;
+    S.busy = true;
+    form.querySelectorAll("button").forEach((button) => { button.disabled = true; });
+    try {
+      const values = new FormData(form);
+      const data = await preferenceRequest("decide", {
+        id: item.id,
+        decision,
+        reason: String(values.get("reason") || "").trim(),
+        shift: decision === "accepted" ? {
+          start: String(values.get("start") || item.start),
+          end: String(values.get("end") || item.end),
+          breakMinutes: Number(values.get("breakMinutes") || item.breakMinutes || 0)
+        } : null
+      });
+      dialog.remove();
+      await refresh(data, decision === "accepted" ? "Schicht wurde in den Dienstplan übernommen." : "Schichtwunsch wurde abgelehnt.");
+    } catch (error) {
+      form.querySelectorAll("button").forEach((button) => { button.disabled = false; });
+      toast(error?.message || "Entscheidung konnte nicht gespeichert werden.", "error");
+    } finally { S.busy = false; }
+  }
+
+  async function cancelPreference(id) {
+    if (S.busy) return;
+    S.busy = true;
+    try { await refresh(await preferenceRequest("cancel", { id }), "Schichtwunsch wurde zurückgezogen."); }
+    catch (error) { toast(error?.message || "Schichtwunsch konnte nicht zurückgezogen werden.", "error"); }
+    finally { S.busy = false; }
+  }
+
+  async function refresh(data, message) {
+    if (typeof loadState === "function") await loadState(true);
+    if (["manager", "owner"].includes(S.accessRole) && typeof uEnsureSchedule === "function") await uEnsureSchedule(true);
+    toast(message);
+    if (typeof render === "function") render();
+    queueMicrotask(decorateEmployeeCalendar);
+    queueMicrotask(decorateManagerSchedule);
+    return data;
+  }
+
+  if (originalEmployeeCalendar) {
+    globalThis.uCalendarPage = function shiftPreferenceCalendarPage() {
+      const markup = originalEmployeeCalendar();
+      queueMicrotask(decorateEmployeeCalendar);
+      return markup;
+    };
+  }
+
+  if (originalAdminView) {
+    globalThis.adminView = function shiftPreferenceAdminView() {
+      const markup = originalAdminView();
+      if (!["manager", "owner"].includes(S.accessRole) || S.adminView !== "schedule") return markup;
+      const scheduleBoard = typeof uFlag === "function" && uFlag("schedule_board_v2");
+      if (scheduleBoard) {
+        queueMicrotask(decorateManagerSchedule);
+        return markup;
+      }
+      return `${markup}${legacyManagerPanel()}`;
+    };
+  }
+
+  document.addEventListener("click", async (event) => {
+    const control = event.target.closest?.("[data-sp-action]");
+    if (!control) return;
+    const action = control.dataset.spAction;
+    if (action === "create") openCreateModal(control.dataset.date || currentDate());
+    else if (action === "review") openReviewModal(String(control.dataset.id || ""));
+    else if (action === "cancel") await cancelPreference(String(control.dataset.id || ""));
+  });
+
+  globalThis.AoraShiftPreferences = Object.freeze({ version: "3.0.0", preferences, decorateEmployeeCalendar, decorateManagerSchedule });
+})();

--- a/aora-v8-final/package.json
+++ b/aora-v8-final/package.json
@@ -4,7 +4,7 @@
   "version": "8.1.0-production",
   "type": "module",
   "scripts": {
-    "check": "node check.mjs && node tests/offline-crypto.mjs && node tests/environment-guard.mjs && node tests/unified-feature-source.mjs && node tests/production-hardening-source.mjs && node tests/interaction-contract.mjs",
+    "check": "node check.mjs && node tests/offline-crypto.mjs && node tests/environment-guard.mjs && node tests/unified-feature-source.mjs && node tests/production-hardening-source.mjs && node tests/interaction-contract.mjs && node tests/shift-preferences-source.mjs",
     "smoke": "node smoke.mjs",
     "build": "npm run check && node build.mjs && node smoke.mjs",
     "test:e2e": "playwright test",

--- a/aora-v8-final/supabase/functions/aora-v8-shift-preferences/index.ts
+++ b/aora-v8-final/supabase/functions/aora-v8-shift-preferences/index.ts
@@ -1,0 +1,84 @@
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.57.4";
+
+const URL = Deno.env.get("SUPABASE_URL")!;
+const SERVICE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+const DEFAULT_ORIGIN = "https://dopamine-blond.vercel.app";
+const PREVIEW_SUFFIX = "-mobins-projects-4f428afa.vercel.app";
+const EXACT_ORIGINS = new Set([
+  DEFAULT_ORIGIN,
+  "https://aora-workforce.vercel.app",
+  "https://dopamine-mobins-projects-4f428afa.vercel.app",
+  "https://dopamine-git-main-mobins-projects-4f428afa.vercel.app"
+]);
+const service = createClient(URL, SERVICE_KEY, { auth: { persistSession: false, autoRefreshToken: false } });
+
+function allowedOrigin(origin: string | null) {
+  if (!origin || origin === "null" || EXACT_ORIGINS.has(origin)) return true;
+  try {
+    const parsed = new globalThis.URL(origin);
+    return (parsed.protocol === "https:" && parsed.hostname.endsWith(PREVIEW_SUFFIX))
+      || (parsed.protocol === "http:" && ["localhost", "127.0.0.1"].includes(parsed.hostname));
+  } catch { return false; }
+}
+function responseHeaders(origin: string | null) {
+  return {
+    "access-control-allow-origin": origin && allowedOrigin(origin) ? origin : DEFAULT_ORIGIN,
+    "access-control-allow-headers": "content-type,authorization,apikey,x-client-info,x-request-id",
+    "access-control-allow-methods": "POST,OPTIONS",
+    "access-control-max-age": "600",
+    "content-type": "application/json; charset=utf-8",
+    "cache-control": "no-store",
+    "x-content-type-options": "nosniff",
+    "vary": "Origin"
+  };
+}
+function reply(body: unknown, status = 200, origin: string | null = null) {
+  return new Response(JSON.stringify(body), { status, headers: responseHeaders(origin) });
+}
+function messageFor(error: any, fallback = "Interner Fehler.") {
+  if (error instanceof Error && error.message) return error.message;
+  if (error && typeof error === "object") return String(error.message || error.details || error.hint || fallback);
+  return error == null ? fallback : String(error);
+}
+function statusFor(error: any) {
+  const code = String(error?.code || "");
+  const message = messageFor(error);
+  if (code === "28000" || /Sitzung.*ungültig|abgelaufen/i.test(message)) return 401;
+  if (code === "42501") return 403;
+  if (code === "P0002") return 404;
+  if (["23505", "40001"].includes(code) || /bereits|nicht mehr offen|überschneidet/i.test(message)) return 409;
+  if (["22023", "P0001"].includes(code)) return 422;
+  return 500;
+}
+
+Deno.serve(async (request: Request) => {
+  const origin = request.headers.get("origin");
+  if (request.method === "OPTIONS") return new Response("ok", { headers: responseHeaders(origin) });
+  if (request.method !== "POST") return reply({ error: "Method not allowed" }, 405, origin);
+  if (origin && !allowedOrigin(origin)) return reply({ error: "Origin not allowed" }, 403, origin);
+
+  try {
+    const body = await request.json();
+    const action = String(body.action || "");
+    if (!["create", "cancel", "decide"].includes(action)) return reply({ error: "Unbekannte Aktion." }, 400, origin);
+    const payload = action === "create"
+      ? (body.preference || {})
+      : action === "decide"
+        ? { decision: body.decision, reason: body.reason || "", shift: body.shift || null }
+        : {};
+    const result = await service.rpc("aora_shift_preference_action", {
+      p_token: String(body.token || ""),
+      p_action: action,
+      p_request_id: body.id ? String(body.id) : null,
+      p_payload: payload,
+      p_idempotency_key: String(body.idempotencyKey || crypto.randomUUID())
+    });
+    if (result.error) return reply({ error: messageFor(result.error), code: result.error.code || null }, statusFor(result.error), origin);
+    return reply(result.data || {}, 200, origin);
+  } catch (error: any) {
+    const message = messageFor(error);
+    console.warn("aora-shift-preference-rejected", { status: error?.status || 500, message });
+    return reply({ error: message }, Number(error?.status || 500), origin);
+  }
+});

--- a/aora-v8-final/supabase/migrations/202608020100_aora_shift_preferences.sql
+++ b/aora-v8-final/supabase/migrations/202608020100_aora_shift_preferences.sql
@@ -1,0 +1,595 @@
+begin;
+
+-- Reuse Aora's canonical shift_requests domain instead of introducing a
+-- second request table. A preference has no shift until it is accepted.
+alter table public.shift_requests alter column shift_id drop not null;
+
+-- Migrate and remove the earlier staging-only experiment if it exists.
+do $migration$
+begin
+  if to_regclass('public.aora_shift_preferences') is not null then
+    execute $copy$
+      insert into public.shift_requests(
+        organization_id,id,shift_id,employee_id,location_id,request_type,status,reason,
+        created_at,decided_at,decided_by,updated_at,payload
+      )
+      select
+        organization_id,
+        id::text,
+        resulting_shift_id,
+        employee_id,
+        location_id,
+        'shift_preference',
+        status,
+        coalesce(decision_reason,note),
+        created_at,
+        decided_at,
+        decided_by,
+        updated_at,
+        jsonb_build_object(
+          'id',id::text,
+          'shiftId',resulting_shift_id,
+          'employeeId',employee_id,
+          'locationId',location_id,
+          'requestType','shift_preference',
+          'status',status,
+          'date',preference_date::text,
+          'start',to_char(start_time,'HH24:MI'),
+          'end',to_char(end_time,'HH24:MI'),
+          'breakMinutes',break_minutes,
+          'note',coalesce(note,''),
+          'reason',coalesce(decision_reason,''),
+          'decidedBy',decided_by,
+          'decidedAt',decided_at,
+          'resultingShiftId',resulting_shift_id,
+          'createdAt',created_at,
+          'updatedAt',updated_at
+        )
+      from public.aora_shift_preferences
+      on conflict(organization_id,id) do nothing
+    $copy$;
+  end if;
+end;
+$migration$;
+
+drop function if exists public.aora_decide_shift_preference(uuid,uuid,bigint,text,text,text,text,text,jsonb);
+drop table if exists public.aora_shift_preferences;
+
+create index if not exists shift_requests_preference_scope_idx
+  on public.shift_requests(organization_id,location_id,status,((payload->>'date')))
+  where request_type='shift_preference' and deleted_at is null;
+
+create index if not exists shift_requests_preference_employee_idx
+  on public.shift_requests(organization_id,employee_id,((payload->>'date')) desc)
+  where request_type='shift_preference' and deleted_at is null;
+
+create unique index if not exists shift_requests_unique_pending_preference_idx
+  on public.shift_requests(
+    organization_id,
+    employee_id,
+    ((payload->>'date')),
+    ((payload->>'start')),
+    ((payload->>'end'))
+  )
+  where request_type='shift_preference' and status='pending' and deleted_at is null;
+
+create or replace function public.aora_shift_preference_action(
+  p_token text,
+  p_action text,
+  p_request_id text default null,
+  p_payload jsonb default '{}'::jsonb,
+  p_idempotency_key uuid default gen_random_uuid()
+) returns jsonb
+language plpgsql
+security definer
+set search_path=public,extensions,pg_temp
+as $function$
+declare
+  v_session record;
+  v_employee public.employees%rowtype;
+  v_request public.shift_requests%rowtype;
+  v_state jsonb;
+  v_revision bigint;
+  v_next_revision bigint;
+  v_access_role text;
+  v_admin_scope text;
+  v_location_id text;
+  v_request_id text;
+  v_shift_id text;
+  v_decision text;
+  v_date date;
+  v_start time;
+  v_end time;
+  v_break_minutes integer;
+  v_note text;
+  v_reason text;
+  v_now timestamptz:=clock_timestamp();
+  v_today date:=(clock_timestamp() at time zone 'Europe/Berlin')::date;
+  v_request_json jsonb;
+  v_shift_json jsonb;
+  v_rule_evaluation jsonb;
+  v_response jsonb;
+  v_existing jsonb;
+  v_action_key text;
+  v_event_type text;
+  v_notification_id text;
+  v_audit_id text;
+  v_notification jsonb;
+  v_audit jsonb;
+begin
+  if p_action not in ('create','cancel','decide') then
+    raise exception using errcode='22023',message='Unbekannte Schichtwunsch-Aktion.';
+  end if;
+  if p_idempotency_key is null then
+    raise exception using errcode='22023',message='Idempotency-Key fehlt.';
+  end if;
+
+  select * into v_session from public.validate_demo_session(p_token) limit 1;
+  if v_session.organization_id is null then
+    raise exception using errcode='28000',message='Sitzung ist ungültig oder abgelaufen.';
+  end if;
+
+  v_access_role:=case when v_session.role='admin' then 'manager' else v_session.role end;
+  if v_session.role='admin' then
+    select coalesce(payload->>'scope','manager') into v_admin_scope
+    from public.admins
+    where organization_id=v_session.organization_id
+      and id=v_session.subject_id
+      and deleted_at is null;
+    if not found then
+      raise exception using errcode='42501',message='Administrationszugang wurde deaktiviert.';
+    end if;
+    v_access_role:=case when v_admin_scope='owner' then 'owner' else 'manager' end;
+  end if;
+
+  v_action_key:='shift_preference_'||p_action;
+  select response into v_existing
+  from public.idempotency_records
+  where organization_id=v_session.organization_id
+    and action=v_action_key
+    and actor_id=v_session.subject_id
+    and idempotency_key=p_idempotency_key
+    and status='completed';
+  if found then return v_existing; end if;
+
+  insert into public.idempotency_records(organization_id,action,actor_id,idempotency_key)
+  values(v_session.organization_id,v_action_key,v_session.subject_id,p_idempotency_key)
+  on conflict do nothing;
+
+  select state,revision into v_state,v_revision
+  from public.workspace_snapshots
+  where organization_id=v_session.organization_id
+  for update;
+  if not found then
+    raise exception using errcode='P0002',message='Arbeitsbereich wurde nicht gefunden.';
+  end if;
+
+  v_state:=coalesce(v_state,'{}'::jsonb);
+  for v_action_key in select unnest(array['shiftRequests','shifts','notifications','audit']) loop
+    if jsonb_typeof(v_state->v_action_key) is distinct from 'array' then
+      v_state:=jsonb_set(v_state,array[v_action_key],'[]'::jsonb,true);
+    end if;
+  end loop;
+  v_action_key:='shift_preference_'||p_action;
+
+  if p_action='create' then
+    if v_session.role<>'employee' then
+      raise exception using errcode='42501',message='Nur Mitarbeiter können Schichtwünsche abgeben.';
+    end if;
+
+    select * into v_employee
+    from public.employees
+    where organization_id=v_session.organization_id
+      and id=v_session.subject_id
+      and active=true
+      and deleted_at is null;
+    if not found then
+      raise exception using errcode='42501',message='Mitarbeiterkonto wurde nicht gefunden.';
+    end if;
+
+    v_location_id:=coalesce(v_employee.primary_location_id,v_employee.location_id);
+    if coalesce(p_payload->>'date','') !~ '^\d{4}-\d{2}-\d{2}$'
+       or coalesce(p_payload->>'start','') !~ '^([01]\d|2[0-3]):[0-5]\d$'
+       or coalesce(p_payload->>'end','') !~ '^([01]\d|2[0-3]):[0-5]\d$'
+       or coalesce(p_payload->>'breakMinutes','0') !~ '^\d{1,3}$' then
+      raise exception using errcode='22023',message='Datum, Uhrzeit oder Pause ist ungültig.';
+    end if;
+    v_date:=(p_payload->>'date')::date;
+    v_start:=(p_payload->>'start')::time;
+    v_end:=(p_payload->>'end')::time;
+    v_break_minutes:=(coalesce(p_payload->>'breakMinutes','0'))::integer;
+    v_note:=trim(coalesce(p_payload->>'note',''));
+
+    if v_location_id is null then
+      raise exception using errcode='22023',message='Für das Mitarbeiterkonto ist kein Standort hinterlegt.';
+    end if;
+    if v_date is null or v_date<v_today or v_date>v_today+180 then
+      raise exception using errcode='22023',message='Schichtwünsche sind nur für die nächsten 180 Tage möglich.';
+    end if;
+    if v_start is null or v_end is null or v_end<=v_start then
+      raise exception using errcode='22023',message='Ende muss nach dem Beginn liegen.';
+    end if;
+    if v_break_minutes<0 or v_break_minutes>180 then
+      raise exception using errcode='22023',message='Pause ist ungültig.';
+    end if;
+    if extract(epoch from (v_end-v_start))/60-v_break_minutes<=0
+       or extract(epoch from (v_end-v_start))/60-v_break_minutes>720 then
+      raise exception using errcode='22023',message='Die gewünschte Schichtdauer ist ungültig.';
+    end if;
+    if char_length(v_note)>240 then
+      raise exception using errcode='22023',message='Die Notiz darf höchstens 240 Zeichen enthalten.';
+    end if;
+
+    if exists(
+      select 1 from public.shift_requests request
+      where request.organization_id=v_session.organization_id
+        and request.employee_id=v_session.subject_id
+        and request.request_type='shift_preference'
+        and request.status='pending'
+        and request.deleted_at is null
+        and request.payload->>'date'=v_date::text
+        and (request.payload->>'start')::time<v_end
+        and (request.payload->>'end')::time>v_start
+    ) then
+      raise exception using errcode='23505',message='Für diesen Zeitraum besteht bereits ein offener Schichtwunsch.';
+    end if;
+
+    v_request_id:='shift_request_'||replace(gen_random_uuid()::text,'-','');
+    v_request_json:=jsonb_build_object(
+      'id',v_request_id,
+      'shiftId',null,
+      'employeeId',v_session.subject_id,
+      'locationId',v_location_id,
+      'requestType','shift_preference',
+      'status','pending',
+      'date',v_date::text,
+      'start',to_char(v_start,'HH24:MI'),
+      'end',to_char(v_end,'HH24:MI'),
+      'breakMinutes',v_break_minutes,
+      'note',v_note,
+      'reason','',
+      'createdAt',v_now,
+      'updatedAt',v_now,
+      'idempotencyKey',p_idempotency_key
+    );
+
+    insert into public.shift_requests(
+      organization_id,id,shift_id,employee_id,location_id,request_type,status,reason,
+      created_at,idempotency_key,updated_at,payload
+    ) values(
+      v_session.organization_id,v_request_id,null,v_session.subject_id,v_location_id,
+      'shift_preference','pending',v_note,v_now,p_idempotency_key,v_now,v_request_json
+    );
+
+    v_state:=jsonb_set(v_state,'{shiftRequests}',coalesce(v_state->'shiftRequests','[]'::jsonb)||jsonb_build_array(v_request_json),true);
+    v_audit_id:='audit_'||replace(gen_random_uuid()::text,'-','');
+    v_audit:=jsonb_build_object(
+      'id',v_audit_id,
+      'action','SHIFT_PREFERENCE_CREATED',
+      'actor',v_session.subject_id,
+      'actorType','employee',
+      'actorId',v_session.subject_id,
+      'entity','shift_request',
+      'entityType','shift_request',
+      'entityId',v_request_id,
+      'createdAt',v_now,
+      'metadata',jsonb_build_object('locationId',v_location_id,'date',v_date,'start',v_start,'end',v_end)
+    );
+    v_state:=jsonb_set(v_state,'{audit}',coalesce(v_state->'audit','[]'::jsonb)||jsonb_build_array(v_audit),true);
+    insert into public.audit_logs(
+      organization_id,id,action,actor,entity,entity_id,created_at,payload,location_id,actor_type,actor_id,entity_type,metadata
+    ) values(
+      v_session.organization_id,v_audit_id,'SHIFT_PREFERENCE_CREATED',v_session.subject_id,'shift_request',v_request_id,v_now,
+      jsonb_build_object('date',v_date,'start',v_start,'end',v_end,'breakMinutes',v_break_minutes,'note',v_note),
+      v_location_id,'employee',v_session.subject_id,'shift_request',jsonb_build_object('requestType','shift_preference')
+    );
+    v_event_type:='SHIFT_PREFERENCE_CREATED';
+
+  elsif p_action='cancel' then
+    if v_session.role<>'employee' then
+      raise exception using errcode='42501',message='Nur Mitarbeiter können eigene Schichtwünsche zurückziehen.';
+    end if;
+
+    select * into v_request
+    from public.shift_requests
+    where organization_id=v_session.organization_id
+      and id=p_request_id
+      and request_type='shift_preference'
+      and deleted_at is null
+    for update;
+    if not found then
+      raise exception using errcode='P0002',message='Schichtwunsch wurde nicht gefunden.';
+    end if;
+    if v_request.employee_id<>v_session.subject_id then
+      raise exception using errcode='42501',message='Dieser Schichtwunsch gehört zu einem anderen Mitarbeiter.';
+    end if;
+    if v_request.status<>'pending' then
+      raise exception using errcode='40001',message='Der Schichtwunsch ist nicht mehr offen.';
+    end if;
+
+    v_location_id:=v_request.location_id;
+    v_request_id:=v_request.id;
+    v_request_json:=v_request.payload||jsonb_build_object(
+      'status','cancelled','cancelledAt',v_now,'updatedAt',v_now
+    );
+
+    update public.shift_requests
+    set status='cancelled',updated_at=v_now,payload=v_request_json
+    where organization_id=v_session.organization_id and id=v_request.id;
+
+    v_state:=jsonb_set(v_state,'{shiftRequests}',coalesce((
+      select jsonb_agg(case when item->>'id'=v_request.id then v_request_json else item end)
+      from jsonb_array_elements(coalesce(v_state->'shiftRequests','[]'::jsonb)) item
+    ),'[]'::jsonb),true);
+    v_audit_id:='audit_'||replace(gen_random_uuid()::text,'-','');
+    v_audit:=jsonb_build_object(
+      'id',v_audit_id,'action','SHIFT_PREFERENCE_CANCELLED','actor',v_session.subject_id,
+      'actorType','employee','actorId',v_session.subject_id,'entity','shift_request','entityType','shift_request',
+      'entityId',v_request.id,'createdAt',v_now,'metadata',jsonb_build_object('locationId',v_location_id)
+    );
+    v_state:=jsonb_set(v_state,'{audit}',coalesce(v_state->'audit','[]'::jsonb)||jsonb_build_array(v_audit),true);
+    insert into public.audit_logs(
+      organization_id,id,action,actor,entity,entity_id,created_at,payload,location_id,actor_type,actor_id,entity_type,metadata
+    ) values(
+      v_session.organization_id,v_audit_id,'SHIFT_PREFERENCE_CANCELLED',v_session.subject_id,'shift_request',v_request.id,v_now,
+      '{}'::jsonb,v_location_id,'employee',v_session.subject_id,'shift_request',jsonb_build_object('requestType','shift_preference')
+    );
+    v_event_type:='SHIFT_PREFERENCE_CANCELLED';
+
+  else
+    if v_session.role<>'admin' then
+      raise exception using errcode='42501',message='Nur Inhaber oder Manager können Schichtwünsche entscheiden.';
+    end if;
+
+    select * into v_request
+    from public.shift_requests
+    where organization_id=v_session.organization_id
+      and id=p_request_id
+      and request_type='shift_preference'
+      and deleted_at is null
+    for update;
+    if not found then
+      raise exception using errcode='P0002',message='Schichtwunsch wurde nicht gefunden.';
+    end if;
+    if v_request.status<>'pending' then
+      raise exception using errcode='40001',message='Der Schichtwunsch wurde bereits entschieden.';
+    end if;
+
+    v_location_id:=v_request.location_id;
+    if v_access_role<>'owner' and not exists(
+      select 1 from public.manager_location_access
+      where organization_id=v_session.organization_id
+        and manager_id=v_session.subject_id
+        and location_id=v_location_id
+    ) then
+      raise exception using errcode='42501',message='Kein Zugriff auf diesen Standort.';
+    end if;
+
+    v_decision:=lower(coalesce(p_payload->>'decision',''));
+    if v_decision not in ('accepted','rejected') then
+      raise exception using errcode='22023',message='Entscheidung ist ungültig.';
+    end if;
+    v_reason:=trim(coalesce(p_payload->>'reason',''));
+    if char_length(v_reason)>240 then
+      raise exception using errcode='22023',message='Die Entscheidungsnotiz darf höchstens 240 Zeichen enthalten.';
+    end if;
+
+    v_request_id:=v_request.id;
+    v_date:=(v_request.payload->>'date')::date;
+    if v_decision='accepted' and (
+      (coalesce(p_payload#>>'{shift,start}',v_request.payload->>'start','') !~ '^([01]\d|2[0-3]):[0-5]\d$')
+      or (coalesce(p_payload#>>'{shift,end}',v_request.payload->>'end','') !~ '^([01]\d|2[0-3]):[0-5]\d$')
+      or (coalesce(p_payload#>>'{shift,breakMinutes}',v_request.payload->>'breakMinutes','0') !~ '^\d{1,3}$')
+    ) then
+      raise exception using errcode='22023',message='Schichtzeit oder Pause ist ungültig.';
+    end if;
+    v_start:=coalesce(nullif(p_payload#>>'{shift,start}','')::time,(v_request.payload->>'start')::time);
+    v_end:=coalesce(nullif(p_payload#>>'{shift,end}','')::time,(v_request.payload->>'end')::time);
+    v_break_minutes:=coalesce(nullif(p_payload#>>'{shift,breakMinutes}','')::integer,coalesce((v_request.payload->>'breakMinutes')::integer,0));
+
+    if v_decision='accepted' then
+      if v_end<=v_start or v_break_minutes<0 or v_break_minutes>180
+         or extract(epoch from (v_end-v_start))/60-v_break_minutes<=0
+         or extract(epoch from (v_end-v_start))/60-v_break_minutes>720 then
+        raise exception using errcode='22023',message='Schichtzeit oder Pause ist ungültig.';
+      end if;
+
+      v_rule_evaluation:=public.aora_evaluate_shift_rules(
+        v_session.organization_id,
+        v_request.employee_id,
+        v_location_id,
+        v_date,
+        v_start,
+        v_end,
+        v_break_minutes,
+        coalesce(v_state->'shifts','[]'::jsonb),
+        null,
+        null,
+        v_access_role,
+        v_session.subject_id
+      );
+      if not coalesce((v_rule_evaluation->>'valid')::boolean,false) then
+        raise exception using errcode='22023',message=case
+          when coalesce((v_rule_evaluation->>'requiresConfirmation')::boolean,false)
+            then 'Bestätigung einer Arbeitszeitregel ist erforderlich.'
+          else 'Der Schichtwunsch verletzt eine blockierende Arbeitszeitregel.'
+        end;
+      end if;
+
+      if exists(
+        select 1 from public.shifts shift
+        where shift.organization_id=v_session.organization_id
+          and shift.employee_id=v_request.employee_id
+          and shift.shift_date=v_date
+          and coalesce(shift.status,'draft')<>'cancelled'
+          and shift.deleted_at is null
+          and v_start<shift.ends_at
+          and v_end>shift.starts_at
+      ) then
+        raise exception using errcode='40001',message='Die Schicht überschneidet sich mit einer bestehenden Schicht.';
+      end if;
+
+      v_shift_id:='shift_'||replace(gen_random_uuid()::text,'-','');
+      v_shift_json:=jsonb_build_object(
+        'id',v_shift_id,
+        'employeeId',v_request.employee_id,
+        'locationId',v_location_id,
+        'date',v_date::text,
+        'start',to_char(v_start,'HH24:MI'),
+        'end',to_char(v_end,'HH24:MI'),
+        'breakMinutes',v_break_minutes,
+        'status','draft',
+        'source','employee_preference',
+        'sourcePreferenceId',v_request.id,
+        'ruleSetId',v_rule_evaluation->>'ruleSetId',
+        'ruleSetVersion',v_rule_evaluation->'ruleSetVersion',
+        'ruleEvaluationId',v_rule_evaluation->>'evaluationId',
+        'ruleOverrides','[]'::jsonb,
+        'version',1,
+        'publishedAt',null,
+        'createdAt',v_now,
+        'createdBy',v_session.subject_id,
+        'updatedAt',v_now,
+        'updatedBy',v_session.subject_id
+      );
+
+      insert into public.shifts(
+        organization_id,id,employee_id,location_id,shift_date,status,payload,
+        starts_at,ends_at,break_minutes,version,created_by,updated_by,created_at,updated_at
+      ) values(
+        v_session.organization_id,v_shift_id,v_request.employee_id,v_location_id,v_date,
+        'draft',v_shift_json,v_start,v_end,v_break_minutes,1,v_session.subject_id,
+        v_session.subject_id,v_now,v_now
+      );
+
+      v_state:=jsonb_set(v_state,'{shifts}',coalesce(v_state->'shifts','[]'::jsonb)||jsonb_build_array(v_shift_json),true);
+      v_event_type:='SHIFT_PREFERENCE_ACCEPTED';
+    else
+      v_event_type:='SHIFT_PREFERENCE_REJECTED';
+    end if;
+
+    v_request_json:=v_request.payload||jsonb_build_object(
+      'shiftId',v_shift_id,
+      'resultingShiftId',v_shift_id,
+      'status',v_decision,
+      'reason',v_reason,
+      'decidedAt',v_now,
+      'decidedBy',v_session.subject_id,
+      'updatedAt',v_now
+    );
+
+    update public.shift_requests
+    set shift_id=v_shift_id,status=v_decision,reason=v_reason,decided_at=v_now,
+        decided_by=v_session.subject_id,updated_at=v_now,payload=v_request_json
+    where organization_id=v_session.organization_id and id=v_request.id;
+
+    v_state:=jsonb_set(v_state,'{shiftRequests}',coalesce((
+      select jsonb_agg(case when item->>'id'=v_request.id then v_request_json else item end)
+      from jsonb_array_elements(coalesce(v_state->'shiftRequests','[]'::jsonb)) item
+    ),'[]'::jsonb),true);
+
+    v_notification_id:='note_'||replace(gen_random_uuid()::text,'-','');
+    v_notification:=jsonb_build_object(
+      'id',v_notification_id,
+      'employeeId',v_request.employee_id,
+      'locationId',v_location_id,
+      'type','shift_preference_decision',
+      'title',case when v_decision='accepted' then 'Schichtwunsch übernommen' else 'Schichtwunsch abgelehnt' end,
+      'body',v_date::text||' · '||to_char(v_start,'HH24:MI')||'–'||to_char(v_end,'HH24:MI')||case when v_reason<>'' then ' · '||v_reason else '' end,
+      'relatedEntityType','shift_request',
+      'relatedEntityId',v_request.id,
+      'read',false,
+      'createdAt',v_now,
+      'idempotencyKey','shift-preference:'||v_request.id||':'||v_decision
+    );
+    v_state:=jsonb_set(v_state,'{notifications}',coalesce(v_state->'notifications','[]'::jsonb)||jsonb_build_array(v_notification),true);
+    insert into public.notifications(
+      organization_id,id,employee_id,read,created_at,payload,location_id,type,title,body,
+      related_entity_type,related_entity_id,idempotency_key
+    ) values(
+      v_session.organization_id,v_notification_id,v_request.employee_id,false,v_now,v_notification,v_location_id,
+      'shift_preference_decision',v_notification->>'title',v_notification->>'body','shift_request',v_request.id,
+      'shift-preference:'||v_request.id||':'||v_decision
+    ) on conflict(organization_id,id) do nothing;
+
+    v_audit_id:='audit_'||replace(gen_random_uuid()::text,'-','');
+    v_audit:=jsonb_build_object(
+      'id',v_audit_id,
+      'action',v_event_type,
+      'actor',v_session.subject_id,
+      'actorType','admin',
+      'actorId',v_session.subject_id,
+      'entity','shift_request',
+      'entityType','shift_request',
+      'entityId',v_request.id,
+      'createdAt',v_now,
+      'payload',jsonb_build_object('shiftId',v_shift_id,'employeeId',v_request.employee_id,'reason',v_reason),
+      'metadata',jsonb_build_object('locationId',v_location_id,'ruleEvaluationId',v_rule_evaluation->>'evaluationId')
+    );
+    v_state:=jsonb_set(v_state,'{audit}',coalesce(v_state->'audit','[]'::jsonb)||jsonb_build_array(v_audit),true);
+    insert into public.audit_logs(
+      organization_id,id,action,actor,entity,entity_id,created_at,payload,location_id,actor_type,actor_id,entity_type,metadata
+    ) values(
+      v_session.organization_id,v_audit_id,v_event_type,v_session.subject_id,'shift_request',v_request.id,v_now,
+      jsonb_build_object('shiftId',v_shift_id,'employeeId',v_request.employee_id,'reason',v_reason),
+      v_location_id,'admin',v_session.subject_id,'shift_request',
+      jsonb_build_object('requestType','shift_preference','ruleEvaluationId',v_rule_evaluation->>'evaluationId')
+    );
+  end if;
+
+  v_state:=jsonb_set(v_state,'{meta}',coalesce(v_state->'meta','{}'::jsonb)||jsonb_build_object(
+    'revision',v_revision+1,'updatedAt',v_now,'variant','isolated-v8-final'
+  ),true);
+
+  v_next_revision:=public.aora_commit_workspace_state(
+    v_session.organization_id,
+    v_revision,
+    v_state,
+    v_access_role,
+    v_session.subject_id,
+    v_event_type,
+    jsonb_build_object(
+      'requestId',coalesce(v_request_id,p_request_id),
+      'shiftId',v_shift_id,
+      'employeeId',coalesce(v_request.employee_id,v_session.subject_id),
+      'locationId',v_location_id,
+      'action',p_action
+    ),
+    'shift_request',
+    coalesce(v_request_id,p_request_id),
+    v_location_id
+  );
+
+  v_response:=jsonb_build_object(
+    'requestId',coalesce(v_request_id,p_request_id),
+    'resultingShiftId',v_shift_id,
+    'revision',v_next_revision,
+    'ruleEvaluation',v_rule_evaluation,
+    'serverTime',v_now
+  );
+
+  update public.idempotency_records
+  set status='completed',response=v_response,updated_at=v_now
+  where organization_id=v_session.organization_id
+    and action=v_action_key
+    and actor_id=v_session.subject_id
+    and idempotency_key=p_idempotency_key;
+
+  return v_response;
+exception when others then
+  if v_session.organization_id is not null and p_idempotency_key is not null then
+    update public.idempotency_records
+    set status='failed',error=sqlerrm,updated_at=clock_timestamp()
+    where organization_id=v_session.organization_id
+      and action=coalesce(v_action_key,'shift_preference_'||coalesce(p_action,'unknown'))
+      and actor_id=v_session.subject_id
+      and idempotency_key=p_idempotency_key;
+  end if;
+  raise;
+end;
+$function$;
+
+revoke all on function public.aora_shift_preference_action(text,text,text,jsonb,uuid) from public,anon,authenticated;
+grant execute on function public.aora_shift_preference_action(text,text,text,jsonb,uuid) to service_role;
+
+commit;

--- a/aora-v8-final/tests/shift-preferences-source.mjs
+++ b/aora-v8-final/tests/shift-preferences-source.mjs
@@ -1,0 +1,42 @@
+import { readFile } from "node:fs/promises";
+import { strict as assert } from "node:assert";
+
+const [ui, edge, migration, index] = await Promise.all([
+  readFile(new URL("../app/modules/shift-preferences.js", import.meta.url), "utf8"),
+  readFile(new URL("../supabase/functions/aora-v8-shift-preferences/index.ts", import.meta.url), "utf8"),
+  readFile(new URL("../supabase/migrations/202608020100_aora_shift_preferences.sql", import.meta.url), "utf8"),
+  readFile(new URL("../app/index.html", import.meta.url), "utf8"),
+]);
+
+assert.match(ui, /originalEmployeeCalendar/);
+assert.match(ui, /originalAdminView/);
+assert.match(ui, /decorateEmployeeCalendar/);
+assert.match(ui, /decorateManagerSchedule/);
+assert.match(ui, /aora-cal-entry aora-cal-entry-shift/);
+assert.match(ui, /class="u-item-card"/);
+assert.match(ui, /class="u-actions"/);
+assert.match(ui, /modalHeader\("Kalender", "Schichtwunsch abgeben"\)/);
+assert.match(ui, /modalHeader\("Dienstplan", "Schichtwunsch prüfen"\)/);
+assert.doesNotMatch(ui, /sp-planner|sp-modal|managerSchedulePage|sp-schedule-page/);
+assert.doesNotMatch(index, /shift-preferences\.css/);
+assert.match(index, /modules\/shift-preferences\.js/);
+assert.match(index, /reports-pdf-mobile-fix\.js/);
+
+assert.match(edge, /aora_shift_preference_action/);
+assert.doesNotMatch(edge, /validate_demo_session/);
+assert.doesNotMatch(edge, /\.from\("aora_shift_preferences"\)/);
+assert.doesNotMatch(edge, /action === "load"/);
+
+assert.match(migration, /alter table public\.shift_requests alter column shift_id drop not null/);
+assert.match(migration, /request_type='shift_preference'/);
+assert.match(migration, /insert into public\.shift_requests/);
+assert.match(migration, /insert into public\.shifts/);
+assert.match(migration, /insert into public\.notifications/);
+assert.match(migration, /insert into public\.audit_logs/);
+assert.match(migration, /aora_evaluate_shift_rules/);
+assert.match(migration, /aora_commit_workspace_state/);
+assert.match(migration, /drop table if exists public\.aora_shift_preferences/);
+assert.match(migration, /drop function if exists public\.aora_decide_shift_preference/);
+assert.doesNotMatch(migration, /create table if not exists public\.aora_shift_preferences/);
+
+console.log("shift preference canonical integration contract: ok");


### PR DESCRIPTION
## Final architecture
- extends the existing employee Aora calendar instead of replacing it
- extends the existing manager schedule board instead of creating a second planner
- uses only native Aora UI primitives (`aora-cal-entry`, `u-item-card`, `u-actions`, `modal`, `form-grid`)
- adds no new stylesheet and no duplicate visual system
- keeps the mobile PDF fix and every current `main` change

## Single source of truth
- reuses the canonical `shift_requests` table with `request_type = shift_preference`
- does not create a second preference table
- manager data comes from the existing `scheduleBoard.shiftRequests` response
- employee data comes from the existing workspace `shiftRequests` state
- the Edge Function is only a thin transport to one transactional database RPC

## Atomic consistency
Accepting a preference updates in one transaction:
- canonical `shift_requests`
- canonical `shifts`
- workspace snapshot and revision
- notification
- audit log and workspace event

The same transaction performs work-rule validation, location authorization, overlap protection and idempotency handling.

## Verified on staging
- migration compiled and applied successfully
- old experimental table/RPC removed
- create: HTTP 200
- accept with edited time and valid rule evaluation: HTTP 200
- reject without creating a shift: HTTP 200
- cancel: passed
- canonical tables and workspace snapshot reconciled by IDs and revision
- all QA data and temporary sessions removed; test revision restored

## GitHub and Vercel validation
- based directly on current `main`: 0 commits behind
- Aora canonical source gate: passed
- offline crypto, environment guard, production hardening and interaction contract: passed
- shift preference canonical integration contract: passed
- canonical build and post-build smoke: passed with 41 modules
- Vercel preview deployment: READY
- Netlify preview: passed
- preview index verified to contain both the mobile PDF fix and shift preference module, with no preference stylesheet

## Existing CI policy note
The overall release workflow is red only because its browser bootstrap endpoint returns the exact response `pull_request_not_allowed` with HTTP 403. Playwright and the four-role browser tests are skipped before they start. This PR does not weaken or change that existing CI security policy.

## Release safety
This PR remains draft. Production Supabase and the production frontend are unchanged.