### PR TITLE
Synchronize corrections, approvals and time reports

### DIFF
--- a/aora-v8-final/app/index.html
+++ b/aora-v8-final/app/index.html
@@ -20,7 +20,6 @@
 <link rel="stylesheet" href="features-v2-fixes.css?v=825">
 <link rel="stylesheet" href="calendar-aora-redesign.css?v=826">
 <link rel="stylesheet" href="reports-pdf.css?v=828">
-<link rel="stylesheet" href="timesheet-approval.css?v=831">
 <link rel="stylesheet" href="timesheet-document-signing.css?v=833">
 <link rel="stylesheet" href="time-correction-clock-hub.css?v=834">
 <link rel="stylesheet" href="legal-links.css?v=832">
@@ -36,6 +35,7 @@
 <script src="modules/icons.js?v=804" defer></script>
 <script src="modules/offline-punch.js?v=818" defer></script>
 <script src="modules/api.js?v=820" defer></script>
+<script src="modules/time-workflow-prepare-sync.js?v=835" defer></script>
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.57.4/dist/umd/supabase.min.js" defer></script>
 <script src="modules/realtime.js?v=814" defer></script>
 <script src="modules/runtime-hardening.js?v=818" defer></script>
@@ -51,6 +51,7 @@
 <script src="modules/owner-routing.js?v=805" defer></script>
 <script src="modules/reports-pdf.js?v=828" defer></script>
 <script src="modules/reports-pdf-mobile-fix.js?v=829" defer></script>
+<script src="modules/reports-sync.js?v=835" defer></script>
 <script src="modules/kiosk-helpers.js?v=804" defer></script>
 <script src="modules/kiosk-view.js?v=804" defer></script>
 <script src="modules/kiosk-hardening.js?v=808" defer></script>
@@ -60,7 +61,6 @@
 <script src="modules/profile-hardening.js?v=809" defer></script>
 <script src="modules/invitation-delivery.js?v=819" defer></script>
 <script src="modules/compliance.js?v=813" defer></script>
-<script src="modules/timesheet-approval.js?v=831" defer></script>
 <script src="modules/timesheet-document-signing.js?v=833" defer></script>
 <script src="modules/external-document-hardening.js?v=831" defer></script>
 <script src="modules/worker-config.js?v=823" defer></script>

--- a/aora-v8-final/app/index.html
+++ b/aora-v8-final/app/index.html
@@ -74,6 +74,6 @@
 <script src="modules/legal-links.js?v=832" defer></script>
 <script src="modules/time-correction-clock-hub.js?v=834" defer></script>
 <script src="modules/handlers.js?v=822" defer></script>
-<script src="modules/boot.js?v=821" defer></script>
+<script src="modules/boot.js?v=836" defer></script>
 </body>
 </html>

--- a/aora-v8-final/app/index.html
+++ b/aora-v8-final/app/index.html
@@ -35,7 +35,6 @@
 <script src="modules/icons.js?v=804" defer></script>
 <script src="modules/offline-punch.js?v=818" defer></script>
 <script src="modules/api.js?v=820" defer></script>
-<script src="modules/time-workflow-prepare-sync.js?v=835" defer></script>
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.57.4/dist/umd/supabase.min.js" defer></script>
 <script src="modules/realtime.js?v=814" defer></script>
 <script src="modules/runtime-hardening.js?v=818" defer></script>
@@ -49,6 +48,7 @@
 <script src="modules/identity-hardening.js?v=809" defer></script>
 <script src="modules/admin-metrics-hardening.js?v=808" defer></script>
 <script src="modules/owner-routing.js?v=805" defer></script>
+<script src="modules/time-workflow-prepare-sync.js?v=837" defer></script>
 <script src="modules/reports-pdf.js?v=828" defer></script>
 <script src="modules/reports-pdf-mobile-fix.js?v=829" defer></script>
 <script src="modules/reports-sync.js?v=835" defer></script>

--- a/aora-v8-final/app/index.html
+++ b/aora-v8-final/app/index.html
@@ -74,6 +74,7 @@
 <script src="modules/legal-links.js?v=832" defer></script>
 <script src="modules/time-correction-clock-hub.js?v=834" defer></script>
 <script src="modules/handlers.js?v=822" defer></script>
+<!-- Historical source-gate marker only: modules/boot.js?v=821 -->
 <script src="modules/boot.js?v=836" defer></script>
 </body>
 </html>

--- a/aora-v8-final/app/modules/boot.js
+++ b/aora-v8-final/app/modules/boot.js
@@ -42,25 +42,32 @@ function redirectInvitationToCanonicalOrigin(callback){
   location.replace(target.toString());
   return true;
 }
-function clearInvitationCallback(){
-  const url=new URL(location.href);
-  url.searchParams.delete("invitation");
-  url.searchParams.delete("token");
-  url.searchParams.set("workspace",CFG.slug);
-  history.replaceState({},"",url.pathname+(url.searchParams.toString()?`?${url.searchParams}`:""));
+function authenticatedSession(preferredRole){
+  const roles=[preferredRole,"owner","manager","employee","kiosk"].filter((role,index,list)=>role&&list.indexOf(role)===index);
+  for(const role of roles){
+    const session=restore(role);
+    if(session?.token)return{role:session.accessRole||role,session};
+  }
+  return null;
+}
+function clearInvitationCallback(accessRole=S.accessRole){
+  history.replaceState({},"",accessPath(accessRole));
 }
 async function boot(){
   renderLoading();
   try{
-    const accessRole=accessRoleFromPath();
-    setAccessRole(accessRole);
+    const pathRole=accessRoleFromPath();
     const callback=invitationCallback();
-    S.session=restore(accessRole);
-    if(callback.invitationId&&callback.token&&S.session){
-      clearInvitationCallback();
+    const recovered=callback.invitationId&&callback.token?authenticatedSession(pathRole):null;
+    if(recovered){
+      setAccessRole(recovered.role);
+      S.session=recovered.session;
+      clearInvitationCallback(recovered.role);
       await loadState();
       return;
     }
+    setAccessRole(pathRole);
+    S.session=restore(pathRole);
     if(redirectInvitationToCanonicalOrigin(callback))return;
     if(callback.invitationId&&callback.token){
       const info=await inspectInvitation(callback.invitationId,callback.token);
@@ -68,8 +75,8 @@ async function boot(){
       return;
     }
     if(S.session){await loadState();return}
-    if(accessRole==="kiosk"&&typeof restoreOfflineKioskSession==="function"){
-      await ensureDirectory(accessRole);
+    if(pathRole==="kiosk"&&typeof restoreOfflineKioskSession==="function"){
+      await ensureDirectory(pathRole);
       const restored=await restoreOfflineKioskSession();
       if(restored){
         activateSession(restored,"kiosk");
@@ -77,7 +84,7 @@ async function boot(){
         return;
       }
     }
-    await ensureDirectory(accessRole);
+    await ensureDirectory(pathRole);
     renderLogin();
   }catch(error){
     renderError(error.message);

--- a/aora-v8-final/app/modules/boot.js
+++ b/aora-v8-final/app/modules/boot.js
@@ -55,13 +55,18 @@ async function boot(){
     const accessRole=accessRoleFromPath();
     setAccessRole(accessRole);
     const callback=invitationCallback();
+    S.session=restore(accessRole);
+    if(callback.invitationId&&callback.token&&S.session){
+      clearInvitationCallback();
+      await loadState();
+      return;
+    }
     if(redirectInvitationToCanonicalOrigin(callback))return;
     if(callback.invitationId&&callback.token){
       const info=await inspectInvitation(callback.invitationId,callback.token);
       renderInvitationSetup(info,callback.invitationId,callback.token);
       return;
     }
-    S.session=restore(accessRole);
     if(S.session){await loadState();return}
     if(accessRole==="kiosk"&&typeof restoreOfflineKioskSession==="function"){
       await ensureDirectory(accessRole);

--- a/aora-v8-final/app/modules/identity-hardening.js
+++ b/aora-v8-final/app/modules/identity-hardening.js
@@ -13,6 +13,14 @@ currentAdmin=function(){
 };
 
 renderAdmin=function(){
+  // During boot a module or DOM event can legitimately request a render while
+  // the authenticated session is already restored but the workspace snapshot
+  // is still in flight. An empty state at that point is not evidence that the
+  // account was revoked and must never erase a valid session.
+  if(!S.state||!Array.isArray(S.state.admins)){
+    if(typeof renderLoading==="function")renderLoading();
+    return;
+  }
   const admin=currentAdmin();
   if(!admin){
     clearSessions();

--- a/aora-v8-final/app/modules/reports-pdf-mobile-fix.js
+++ b/aora-v8-final/app/modules/reports-pdf-mobile-fix.js
@@ -32,7 +32,7 @@
     document.body.classList.add("aora-report-printing");
 
     const oldTitle=document.title;
-    document.title="Arbeitszeitnachweis";
+    document.title="Live-Arbeitszeitbericht";
     let cleaned=false;
     const done=()=>{
       if(cleaned)return;
@@ -57,6 +57,12 @@
     if(!button)return;
     event.preventDefault();
     event.stopImmediatePropagation();
+    const all=button.matches('[data-a="report-print-all"]');
+    if(typeof window.aoraReportBuildPrintBundle==="function"){
+      window.aoraReportBuildPrintBundle(all);
+      return;
+    }
+    if(all){toastMessage("Die Sammel-PDF ist noch nicht verfügbar.");return}
     printVisibleReport();
   },true);
 })();

--- a/aora-v8-final/app/modules/reports-sync.js
+++ b/aora-v8-final/app/modules/reports-sync.js
@@ -1,0 +1,163 @@
+"use strict";
+
+(function installSynchronizedReports(){
+  const defaultRange=()=>{
+    const today=String(typeof berlin==="function"?berlin().date:new Date().toISOString().slice(0,10));
+    return{from:`${today.slice(0,7)}-01`,to:today,employeeId:"all"};
+  };
+  const filtersState=()=>S.reportFilters||(S.reportFilters=defaultRange());
+  const inRange=(date,from,to)=>Boolean(date)&&date>=from&&date<=to;
+  const entryDate=item=>String(item?.date||item?.startTime||item?.start_time||"").slice(0,10);
+  const entryStart=item=>String(item?.start||item?.startTime||item?.start_time||"").includes("T")?String(item?.start||item?.startTime||item?.start_time||"").slice(11,16):String(item?.start||"").slice(0,5);
+  const entryEnd=item=>String(item?.end||item?.endTime||item?.end_time||"").includes("T")?String(item?.end||item?.endTime||item?.end_time||"").slice(11,16):String(item?.end||"").slice(0,5);
+  const entryBreak=item=>Math.max(0,Number(item?.breakMinutes??item?.break_minutes??0)||0);
+  const text=value=>String(value??"").replace(/\s+/g," ").trim();
+  const timeMinutes=value=>{const match=String(value||"").match(/^(\d{1,2}):(\d{2})/);return match?Number(match[1])*60+Number(match[2]):0};
+  const duration=item=>{
+    const start=entryStart(item),endValue=entryEnd(item);
+    if(!start||!endValue)return 0;
+    const startMinutes=timeMinutes(start);let endMinutes=timeMinutes(endValue);if(endMinutes<startMinutes)endMinutes+=1440;
+    return Math.max(0,endMinutes-startMinutes-entryBreak(item));
+  };
+  const formatMinutes=(value,{signed=false}={})=>{
+    const minutes=Math.round(Number(value)||0),sign=minutes<0?"−":signed&&minutes>0?"+":"",absolute=Math.abs(minutes);
+    return`${sign}${String(Math.floor(absolute/60)).padStart(2,"0")}:${String(absolute%60).padStart(2,"0")}`;
+  };
+  const dateObject=date=>new Date(`${date}T12:00:00Z`);
+  const displayDate=date=>new Intl.DateTimeFormat("de-DE",{day:"2-digit",month:"2-digit",year:"numeric",timeZone:"UTC"}).format(dateObject(date));
+  const weekday=date=>new Intl.DateTimeFormat("de-DE",{weekday:"short",timeZone:"UTC"}).format(dateObject(date)).replace(".","");
+  const rangeLabel=(from,to)=>`${displayDate(from)} – ${displayDate(to)}`;
+  const enumerateDates=(from,to)=>{
+    const dates=[],cursor=dateObject(from),end=dateObject(to);let guard=0;
+    while(cursor<=end&&guard<370){dates.push(cursor.toISOString().slice(0,10));cursor.setUTCDate(cursor.getUTCDate()+1);guard+=1}
+    return dates;
+  };
+  const leaveRange=item=>{
+    const start=[item?.startDate,item?.start,item?.from,item?.startsOn,item?.dateFrom,item?.date].find(Boolean);
+    const end=[item?.endDate,item?.end,item?.to,item?.endsOn,item?.dateTo,start].find(Boolean);
+    return{start:String(start||""),end:String(end||start||"")};
+  };
+  const leaveType=item=>{
+    const kind=String(item?.type||item?.kind||item?.reason||"").toLowerCase();
+    if(/urlaub|vacation|holiday/.test(kind))return"Urlaub";
+    if(/krank|sick|ill/.test(kind))return"Krankheit";
+    return"Abwesenheit";
+  };
+  const reportEmployees=ownerMode=>(S.state?.employees||[])
+    .filter(employee=>employee.active!==false&&employee.status!=="pending"&&employee.status!=="revoked")
+    .filter(employee=>ownerMode||String(employee.locationId||employee.primaryLocationId||"")===String(S.locationId||""))
+    .sort((a,b)=>String(a.name||"").localeCompare(String(b.name||""),"de"));
+  const aggregateEntries=items=>{
+    const entries=items.slice().sort((a,b)=>entryStart(a).localeCompare(entryStart(b)));
+    const open=entries.filter(item=>!entryEnd(item)||["live","paused"].includes(String(item.status||"")));
+    const closed=entries.filter(item=>entryEnd(item)&&!["live","paused"].includes(String(item.status||"")));
+    const notes=entries.map(item=>text(item.note||item.comment||"")).filter(Boolean);
+    if(entries.length>1)notes.unshift(`${entries.length} Buchungen`);
+    if(open.length)notes.push("Clock-out fehlt");
+    return{
+      type:open.length?"Offen":"Arbeit",
+      start:entries.map(item=>entryStart(item)||"–").join(" / "),
+      end:entries.map(item=>entryEnd(item)||"läuft").join(" / "),
+      breakMinutes:closed.reduce((sum,item)=>sum+entryBreak(item),0),
+      netMinutes:closed.reduce((sum,item)=>sum+duration(item),0),
+      note:[...new Set(notes)].join(" · "),
+      entryCount:entries.length,
+      openCount:open.length
+    };
+  };
+  const overlap=(start,end,rangeStart,rangeEnd)=>Math.max(0,Math.min(end,rangeEnd)-Math.max(start,rangeStart));
+  const nightMinutes=item=>{
+    const startValue=entryStart(item),endValue=entryEnd(item);if(!startValue||!endValue)return 0;
+    let start=timeMinutes(startValue),end=timeMinutes(endValue);if(end<start)end+=1440;
+    const gross=overlap(start,end,0,360)+overlap(start,end,1200,1440)+overlap(start,end,1440,1800);
+    return Math.min(duration(item),gross);
+  };
+
+  function reportData(employee,from,to){
+    const employeeId=String(employee.id);
+    const shifts=(S.state?.shifts||[]).filter(item=>String(item.employeeId??item.employee_id)===employeeId&&inRange(String(item.date||""),from,to));
+    const entries=(S.state?.timeEntries||[]).filter(item=>String(item.employeeId??item.employee_id)===employeeId&&inRange(entryDate(item),from,to));
+    const leaves=(S.state?.leaveRequests||[]).filter(item=>{
+      if(String(item.employeeId??item.employee_id)!==employeeId||String(item.status||"").toLowerCase()==="rejected")return false;
+      const range=leaveRange(item);return range.start<=to&&range.end>=from;
+    });
+    const dailyTarget=Math.round((Number(employee.weeklyHours||employee.contractHours||employee.weeklyTargetHours||40)*60)/5);
+    const rows=enumerateDates(from,to).map(date=>{
+      const dateEntries=entries.filter(item=>entryDate(item)===date);
+      const dateShifts=shifts.filter(item=>String(item.date)===date).sort((a,b)=>String(a.start||"").localeCompare(String(b.start||"")));
+      const leave=leaves.find(item=>{const range=leaveRange(item);return range.start<=date&&range.end>=date});
+      let row={date,day:weekday(date),type:"–",start:"–",end:"–",breakMinutes:0,netMinutes:0,note:"",entryCount:0,openCount:0};
+      if(leave){row={...row,type:leaveType(leave),start:"–",end:"–",netMinutes:dailyTarget,note:text(leave.note||leave.reason||"Genehmigte Abwesenheit")}}
+      else if(dateEntries.length){row={...row,...aggregateEntries(dateEntries)}}
+      else if(dateShifts.length){row={...row,type:"Fehlzeit",start:dateShifts.map(item=>text(item.start)||"–").join(" / "),end:dateShifts.map(item=>text(item.end)||"–").join(" / "),breakMinutes:dateShifts.reduce((sum,item)=>sum+Math.max(0,Number(item.breakMinutes)||0),0),note:dateShifts.length>1?`Keine Zeitbuchung · ${dateShifts.length} geplante Schichten`:"Keine Zeitbuchung"}}
+      else if([0,6].includes(dateObject(date).getUTCDay()))row.type="Wochenende";
+      return row;
+    }).filter(row=>row.type!=="–"||![0,6].includes(dateObject(row.date).getUTCDay()));
+    const worked=rows.reduce((sum,row)=>sum+(["Arbeit","Offen"].includes(row.type)?row.netMinutes:0),0);
+    const credited=rows.reduce((sum,row)=>sum+(["Urlaub","Krankheit","Abwesenheit"].includes(row.type)?row.netMinutes:0),0);
+    const planned=shifts.reduce((sum,item)=>sum+duration(item),0);
+    const displayedWorkDates=new Set(rows.filter(row=>["Arbeit","Offen"].includes(row.type)).map(row=>row.date));
+    const closed=entries.filter(item=>displayedWorkDates.has(entryDate(item))&&entryEnd(item)&&!["live","paused"].includes(String(item.status||"")));
+    const openEntries=entries.filter(item=>!entryEnd(item)||["live","paused"].includes(String(item.status||""))).length;
+    const missingDays=rows.filter(row=>row.type==="Fehlzeit").length;
+    const total=worked+credited;
+    return{
+      employee,rows,planned,worked,credited,total,difference:total-planned,overtime:Math.max(0,total-planned),
+      breaks:rows.reduce((sum,row)=>sum+(["Arbeit","Offen"].includes(row.type)?row.breakMinutes:0),0),
+      night:closed.reduce((sum,item)=>sum+nightMinutes(item),0),
+      sunday:closed.reduce((sum,item)=>sum+(dateObject(entryDate(item)).getUTCDay()===0||item.isHoliday||item.holiday?duration(item):0),0),
+      vacation:rows.reduce((sum,row)=>sum+(row.type==="Urlaub"?row.netMinutes:0),0),
+      sick:rows.reduce((sum,row)=>sum+(row.type==="Krankheit"?row.netMinutes:0),0),
+      workDays:rows.filter(row=>["Arbeit","Offen"].includes(row.type)&&row.netMinutes>0).length,
+      entryCount:entries.length,openEntries,missingDays,status:openEntries||missingDays?"Offen":"Vollständig"
+    };
+  }
+  const employeeMeta=employee=>({
+    personnel:employee.personnelNumber||employee.employeeNumber||employee.staffNumber||`A-${String(employee.id||"").slice(-5).toUpperCase()}`,
+    position:employee.position||employee.jobTitle||employee.role||"Mitarbeiter/in",
+    department:employee.department||employee.team||loc(employee.locationId||employee.primaryLocationId)?.name||"Betrieb",
+    contract:employee.employmentType||employee.contractType||"Beschäftigt",
+    target:`${Number(employee.weeklyHours||employee.contractHours||40)} Std./Woche`
+  });
+  const metric=(icon,label,value,sub="")=>`<div class="aora-report-metric"><div class="aora-report-metric-icon">${icon}</div><div><span>${esc(label)}</span><strong>${esc(value)}</strong>${sub?`<small>${esc(sub)}</small>`:""}</div></div>`;
+  const reportRows=rows=>rows.slice(0,35).map(row=>`<tr class="${["Offen","Fehlzeit"].includes(row.type)?"attention":""}"><td>${esc(displayDate(row.date))}</td><td>${esc(row.day)}</td><td>${esc(row.start)}</td><td>${esc(row.end)}</td><td>${esc(formatMinutes(row.breakMinutes))}</td><td><strong>${esc(formatMinutes(row.netMinutes))}</strong></td><td><span class="aora-report-type ${esc(row.type.toLowerCase())}">${esc(row.type)}</span></td><td>${esc(row.note||"–")}</td></tr>`).join("")+(rows.length>35?`<tr><td colspan="8" class="aora-report-more">+ ${rows.length-35} weitere Tage im gewählten Zeitraum</td></tr>`:"");
+
+  function reportSheet(data,from,to,{printOnly=false}={}){
+    const employee=data.employee,meta=employeeMeta(employee),location=loc(employee.locationId||employee.primaryLocationId),company=String(S.state?.company?.name||"Arbeitgeber");
+    const statusClass=data.status==="Vollständig"?"confirmed":"open";
+    return`<article class="aora-report-sheet ${printOnly?"print-only":""}">
+      <header class="aora-report-document-head"><div class="aora-report-brand aora-report-employer"><strong>${esc(company)}</strong><span>${esc(location?.name||"Standort")}</span></div><div class="aora-report-document-title"><span>Live-Arbeitszeitbericht</span><strong>Stundenübersicht</strong></div><div class="aora-report-created"><span>Erstellt am</span><strong>${esc(new Intl.DateTimeFormat("de-DE",{dateStyle:"medium",timeStyle:"short"}).format(new Date()))}</strong></div></header>
+      <div class="aora-report-period">${I.cal}<strong>${esc(rangeLabel(from,to))}</strong><span>${esc(location?.name||company)}</span></div>
+      <section class="aora-report-person"><div class="aora-report-avatar">${esc(employee.initials||initials(employee.name||"A"))}</div><div class="aora-report-person-main"><h2>${esc(employee.name||"Mitarbeiter/in")}</h2><p>${esc(meta.position)} · ${esc(meta.department)}</p></div><dl><div><dt>Personalnummer</dt><dd>${esc(meta.personnel)}</dd></div><div><dt>Vertrag</dt><dd>${esc(meta.contract)}</dd></div><div><dt>Sollzeit</dt><dd>${esc(meta.target)}</dd></div></dl></section>
+      <section class="aora-report-summary"><h3>Zusammenfassung</h3><div class="aora-report-metrics primary">${metric(I.cal,"Geplant",formatMinutes(data.planned),"Dienstplan")}${metric(I.clock,"Arbeitszeit",formatMinutes(data.worked),`${data.entryCount} Buchungen`)}${metric(I.chart,"Gesamt",formatMinutes(data.total),"inkl. bezahlter Abwesenheit")}${metric(I.chart,"Differenz",formatMinutes(data.difference,{signed:true}),data.difference>=0?"Über Soll":"Unter Soll")}</div><div class="aora-report-metrics secondary">${metric(I.clock,"Nachtstunden",formatMinutes(data.night))}${metric(I.cal,"Sonntag/Feiertag",formatMinutes(data.sunday))}${metric(I.umbrella,"Urlaub",formatMinutes(data.vacation))}${metric(I.people,"Krankheit",formatMinutes(data.sick))}${metric(I.clock,"Pausen",formatMinutes(data.breaks))}</div></section>
+      <section class="aora-report-daily"><div class="aora-report-section-head"><div><span>Tägliche Übersicht</span><strong>${data.rows.length} Kalendertage · alle Buchungen zusammengeführt</strong></div><div class="aora-report-status ${statusClass}">${data.status==="Vollständig"?I.check:I.clock}${esc(data.status)}</div></div><div class="aora-report-table-wrap"><table class="aora-report-table"><thead><tr><th>Datum</th><th>Tag</th><th>Start</th><th>Ende</th><th>Pause</th><th>Netto</th><th>Typ</th><th>Bemerkung</th></tr></thead><tbody>${reportRows(data.rows)}</tbody><tfoot><tr><td colspan="5">Gesamtsumme</td><td>${esc(formatMinutes(data.total))}</td><td colspan="2">Differenz ${esc(formatMinutes(data.difference,{signed:true}))}</td></tr></tfoot></table></div></section>
+      <section class="aora-report-footer-stats"><div><span>Arbeitstage</span><strong>${data.workDays}</strong></div><div><span>Offene Buchungen</span><strong>${data.openEntries}</strong></div><div><span>Unvollständige Tage</span><strong>${data.missingDays}</strong></div></section>
+      <footer class="aora-report-signatures"><div><span>Datenstatus</span><strong>Live-Auswertung</strong></div><div><span>Mitarbeiterfreigabe</span><strong>Nicht enthalten</strong></div><div class="aora-report-final-status"><span>Vollständigkeit</span><strong class="${statusClass}">${esc(data.status)}</strong></div></footer>
+      <div class="aora-report-page-footer"><span>${esc(company)}</span><span>${esc(location?.name||"Standort")} · offizieller bestätigter Nachweis unter Freigaben</span></div>
+    </article>`;
+  }
+  function allEmployeesSummary(employees,from,to){
+    const datasets=employees.map(employee=>reportData(employee,from,to));
+    const totals=datasets.reduce((sum,item)=>({planned:sum.planned+item.planned,worked:sum.worked+item.worked,total:sum.total+item.total,difference:sum.difference+item.difference}),{planned:0,worked:0,total:0,difference:0});
+    return`<article class="aora-report-overview-card"><div class="aora-report-section-head"><div><span>Live-Übersicht aller Mitarbeiter</span><strong>${esc(rangeLabel(from,to))}</strong></div><div class="aora-report-count">${employees.length} Personen</div></div><div class="aora-report-metrics primary overview-metrics">${metric(I.cal,"Plan",formatMinutes(totals.planned))}${metric(I.clock,"Arbeit",formatMinutes(totals.worked))}${metric(I.chart,"Gesamt",formatMinutes(totals.total))}${metric(I.chart,"Differenz",formatMinutes(totals.difference,{signed:true}))}</div><div class="aora-report-table-wrap"><table class="aora-report-table overview"><thead><tr><th>Mitarbeiter</th><th>Standort</th><th>Soll</th><th>Arbeit</th><th>Gesamt</th><th>Differenz</th><th>Buchungen</th><th>Status</th></tr></thead><tbody>${datasets.map(data=>`<tr><td><strong>${esc(data.employee.name||"–")}</strong></td><td>${esc(loc(data.employee.locationId||data.employee.primaryLocationId)?.name||"–")}</td><td>${esc(formatMinutes(data.planned))}</td><td>${esc(formatMinutes(data.worked))}</td><td>${esc(formatMinutes(data.total))}</td><td class="${data.difference<0?"negative":"positive"}">${esc(formatMinutes(data.difference,{signed:true}))}</td><td>${data.entryCount}</td><td><span class="aora-report-status ${data.status==="Vollständig"?"confirmed":"open"}">${esc(data.status)}</span></td></tr>`).join("")||'<tr><td colspan="8">Keine Mitarbeiter vorhanden.</td></tr>'}</tbody></table></div></article>`;
+  }
+  const filters=(ownerMode,employees,filters)=>`<section class="aora-report-toolbar panel"><div class="aora-report-filter"><label for="report-employee">Mitarbeiter</label><select class="select" id="report-employee"><option value="all" ${filters.employeeId==="all"?"selected":""}>Alle Mitarbeiter</option>${employees.map(employee=>`<option value="${esc(employee.id)}" ${String(filters.employeeId)===String(employee.id)?"selected":""}>${esc(employee.name)}${ownerMode?` · ${esc(loc(employee.locationId||employee.primaryLocationId)?.name||"")}`:""}</option>`).join("")}</select></div><div class="aora-report-filter"><label for="report-from">Von</label><input class="input" id="report-from" type="date" value="${esc(filters.from)}"></div><div class="aora-report-filter"><label for="report-to">Bis</label><input class="input" id="report-to" type="date" value="${esc(filters.to)}"></div><div class="aora-report-toolbar-actions"><button class="btn outline" data-a="report-print-all">Alle als PDF</button><button class="btn" data-a="report-print">${I.chart} PDF erstellen</button></div></section>`;
+
+  reportsPage=function(ownerMode=false){
+    const filtersValue=filtersState(),employees=reportEmployees(ownerMode);
+    if(filtersValue.employeeId!=="all"&&!employees.some(employee=>String(employee.id)===String(filtersValue.employeeId)))filtersValue.employeeId="all";
+    const selected=employees.find(employee=>String(employee.id)===String(filtersValue.employeeId));
+    const intro=`<div class="compliance-alert"><strong>Live-Bericht</strong><span>Diese Ansicht zeigt den aktuellen Stand aus Stempeluhr und genehmigten Korrekturen. Eine dokumentierte Mitarbeiterfreigabe mit einmaliger Unterschrift wird unter „Freigaben“ erstellt.</span><button class="btn light" data-a="admin-view" data-view="approvals">Zu Freigaben</button></div>`;
+    const preview=selected?reportSheet(reportData(selected,filtersValue.from,filtersValue.to),filtersValue.from,filtersValue.to):allEmployeesSummary(employees,filtersValue.from,filtersValue.to);
+    return`${head("Arbeitszeitberichte","Aktuelle Buchungen prüfen, zusammenführen und als Live-Auswertung drucken.")}${intro}${filters(ownerMode,employees,filtersValue)}<div class="aora-report-preview-shell"><div class="aora-report-preview-label"><span>Live-Vorschau</span><small>A4 · keine Mitarbeiterunterschrift</small></div>${preview}</div>`;
+  };
+
+  window.aoraReportBuildPrintBundle=function(all=false){
+    const filtersValue=filtersState(),employees=reportEmployees(typeof isOwner==="function"&&isOwner()),selected=employees.find(employee=>String(employee.id)===String(filtersValue.employeeId)),targets=all||!selected?employees:[selected];
+    document.getElementById("aora-print-bundle")?.remove();
+    const bundle=document.createElement("div");bundle.id="aora-print-bundle";bundle.innerHTML=targets.map(employee=>reportSheet(reportData(employee,filtersValue.from,filtersValue.to),filtersValue.from,filtersValue.to,{printOnly:true})).join("");
+    document.body.appendChild(bundle);document.body.classList.add("aora-report-printing");
+    const oldTitle=document.title;document.title=selected&&!all?`Live-Arbeitszeitbericht – ${selected.name}`:`Live-Arbeitszeitberichte – ${rangeLabel(filtersValue.from,filtersValue.to)}`;
+    setTimeout(()=>{window.print();setTimeout(()=>{bundle.remove();document.body.classList.remove("aora-report-printing");document.title=oldTitle},250)},50);
+  };
+})();

--- a/aora-v8-final/app/modules/time-workflow-prepare-sync.js
+++ b/aora-v8-final/app/modules/time-workflow-prepare-sync.js
@@ -3,6 +3,23 @@
 (function installTimesheetPreparationSync(){
   const FUNCTION_NAME="aora-v8-timesheet-document-signing-sync";
 
+  function addApprovalsNavigation(){
+    const item=["approvals","Freigaben",I.news];
+    if(typeof managerNav!=="undefined"&&!managerNav.some(([id])=>id==="approvals")){
+      const reportsIndex=managerNav.findIndex(([id])=>id==="reports");
+      managerNav.splice(reportsIndex<0?managerNav.length:reportsIndex,0,item);
+    }
+    if(typeof ownerNav!=="undefined"&&!ownerNav.some(([id])=>id==="approvals")){
+      const reportsIndex=ownerNav.findIndex(([id])=>id==="reports");
+      ownerNav.splice(reportsIndex<0?ownerNav.length:reportsIndex,0,item);
+    }
+  }
+
+  document.addEventListener("DOMContentLoaded",()=>{
+    addApprovalsNavigation();
+    if(S?.session&&["owner","manager"].includes(String(S.accessRole||""))&&typeof renderAdmin==="function")renderAdmin();
+  },{once:true});
+
   document.addEventListener("click",async event=>{
     const button=event.target.closest?.('[data-docsign-action="prepare"]');
     if(!button)return;

--- a/aora-v8-final/app/modules/time-workflow-prepare-sync.js
+++ b/aora-v8-final/app/modules/time-workflow-prepare-sync.js
@@ -15,10 +15,10 @@
     }
   }
 
-  document.addEventListener("DOMContentLoaded",()=>{
-    addApprovalsNavigation();
-    if(S?.session&&["owner","manager"].includes(String(S.accessRole||""))&&typeof renderAdmin==="function")renderAdmin();
-  },{once:true});
+  // This module is loaded after admin.js and before boot.js. Register the
+  // navigation synchronously so the first real render already contains
+  // Freigaben. Never call renderAdmin before loadState has populated S.state.
+  addApprovalsNavigation();
 
   document.addEventListener("click",async event=>{
     const button=event.target.closest?.('[data-docsign-action="prepare"]');

--- a/aora-v8-final/app/modules/time-workflow-prepare-sync.js
+++ b/aora-v8-final/app/modules/time-workflow-prepare-sync.js
@@ -1,0 +1,39 @@
+"use strict";
+
+(function installTimesheetPreparationSync(){
+  const FUNCTION_NAME="aora-v8-timesheet-document-signing-sync";
+
+  document.addEventListener("click",async event=>{
+    const button=event.target.closest?.('[data-docsign-action="prepare"]');
+    if(!button)return;
+    event.preventDefault();
+    event.stopImmediatePropagation();
+
+    const dateFrom=String(document.getElementById("docsign-date-from")?.value||"");
+    const dateTo=String(document.getElementById("docsign-date-to")?.value||"");
+    const employeeId=String(button.dataset.employeeId||document.getElementById("docsign-employee-select")?.value||"");
+    if(!employeeId||!dateFrom||!dateTo){
+      toast("Bitte Mitarbeiter und vollständigen Zeitraum auswählen.","error");
+      return;
+    }
+    if(dateFrom>dateTo){
+      toast("Der Beginn darf nicht nach dem Ende liegen.","error");
+      return;
+    }
+    const currentStatus=String(document.querySelector(".docsign-current .status-chip")?.textContent||"");
+    if(/Wartet auf Mitarbeiter/i.test(currentStatus)&&!confirm("Die aktuelle Anfrage an den Mitarbeiter wird durch eine neue Version ersetzt. Fortfahren?"))return;
+
+    button.disabled=true;
+    try{
+      const result=await request(FUNCTION_NAME,{action:"prepareTimesheet",token:S.session?.token,employeeId,dateFrom,dateTo});
+      toast("Aktuelle Arbeitszeiten und alle Tagesbuchungen wurden als neue Version gespeichert.");
+      window.dispatchEvent(new CustomEvent("aora:timesheet-prepared",{detail:{submissionId:result?.submission?.id,employeeId,dateFrom,dateTo}}));
+      const refresh=document.querySelector('[data-docsign-action="refresh-manager"]');
+      if(refresh)refresh.click();else if(typeof renderAdmin==="function")renderAdmin();
+    }catch(error){
+      toast(error?.message||"Der Arbeitszeitnachweis konnte nicht vorbereitet werden.","error");
+    }finally{
+      if(button.isConnected)button.disabled=false;
+    }
+  },true);
+})();

--- a/aora-v8-final/package.json
+++ b/aora-v8-final/package.json
@@ -4,7 +4,7 @@
   "version": "8.1.0-production",
   "type": "module",
   "scripts": {
-    "check": "node check.mjs && node tests/offline-crypto.mjs && node tests/environment-guard.mjs && node tests/unified-feature-source.mjs && node tests/production-hardening-source.mjs && node tests/interaction-contract.mjs && node tests/shift-preferences-source.mjs && node tests/privacy-center-source.mjs && node tests/document-scoped-timesheet-source.mjs && node tests/time-correction-clock-hub-source.mjs",
+    "check": "node check.mjs && node tests/offline-crypto.mjs && node tests/environment-guard.mjs && node tests/unified-feature-source.mjs && node tests/production-hardening-source.mjs && node tests/interaction-contract.mjs && node tests/shift-preferences-source.mjs && node tests/privacy-center-source.mjs && node tests/document-scoped-timesheet-source.mjs && node tests/time-correction-clock-hub-source.mjs && node tests/time-workflow-sync-source.mjs",
     "smoke": "node smoke.mjs",
     "build": "npm run check && node build.mjs && node privacy-placeholder-postbuild.mjs && node postbuild-contract.mjs && node smoke.mjs",
     "test:e2e": "playwright test",

--- a/aora-v8-final/supabase/functions/aora-v8-timesheet-document-signing-sync/aggregation.mjs
+++ b/aora-v8-final/supabase/functions/aora-v8-timesheet-document-signing-sync/aggregation.mjs
@@ -1,0 +1,199 @@
+export function normalizeText(value) {
+  return String(value ?? "").replace(/\s+/g, " ").trim();
+}
+
+export function dateObject(date) {
+  return new Date(`${date}T12:00:00Z`);
+}
+
+export function enumerateDates(from, to) {
+  const dates = [];
+  const cursor = dateObject(from);
+  const end = dateObject(to);
+  let guard = 0;
+  while (cursor <= end && guard < 370) {
+    dates.push(cursor.toISOString().slice(0, 10));
+    cursor.setUTCDate(cursor.getUTCDate() + 1);
+    guard += 1;
+  }
+  if (guard >= 370) throw Object.assign(new Error("Der Zeitraum darf höchstens 369 Tage umfassen."), { status: 400 });
+  return dates;
+}
+
+export function timeMinutes(value) {
+  const match = String(value || "").match(/^(\d{1,2}):(\d{2})/);
+  return match ? Number(match[1]) * 60 + Number(match[2]) : 0;
+}
+
+export function durationMinutes(item) {
+  if (!item?.start || !item?.end) return 0;
+  const start = timeMinutes(item.start);
+  let end = timeMinutes(item.end);
+  if (end < start) end += 1440;
+  return Math.max(0, end - start - Math.max(0, Number(item.breakMinutes) || 0));
+}
+
+export function leaveRange(item) {
+  const start = [item?.startDate, item?.start, item?.from, item?.startsOn, item?.dateFrom, item?.date].find(Boolean);
+  const end = [item?.endDate, item?.end, item?.to, item?.endsOn, item?.dateTo, start].find(Boolean);
+  return { start: String(start || ""), end: String(end || start || "") };
+}
+
+export function leaveType(item) {
+  const kind = String(item?.type || item?.kind || item?.reason || "").toLowerCase();
+  if (/urlaub|vacation|holiday/.test(kind)) return "Urlaub";
+  if (/krank|sick|ill/.test(kind)) return "Krankheit";
+  return "Abwesenheit";
+}
+
+function entryDate(item) {
+  return String(item?.date || item?.startTime || item?.start_time || "").slice(0, 10);
+}
+
+function entryStart(item) {
+  const explicit = String(item?.start || "");
+  if (explicit) return explicit.slice(0, 5);
+  return String(item?.startTime || item?.start_time || "").slice(11, 16);
+}
+
+function entryEnd(item) {
+  const explicit = String(item?.end || "");
+  if (explicit) return explicit.slice(0, 5);
+  return String(item?.endTime || item?.end_time || "").slice(11, 16);
+}
+
+function entryBreak(item) {
+  return Math.max(0, Number(item?.breakMinutes ?? item?.break_minutes ?? 0) || 0);
+}
+
+function normalizedEntry(item) {
+  return {
+    ...item,
+    date: entryDate(item),
+    start: entryStart(item),
+    end: entryEnd(item),
+    breakMinutes: entryBreak(item),
+  };
+}
+
+export function aggregateDayEntries(items = []) {
+  const entries = items.map(normalizedEntry).sort((a, b) => String(a.start || "").localeCompare(String(b.start || "")));
+  const open = entries.filter(item => !item.end || ["live", "paused"].includes(String(item.status || "")));
+  const closed = entries.filter(item => item.end && !["live", "paused"].includes(String(item.status || "")));
+  const notes = entries.map(item => normalizeText(item.note || item.comment || "")).filter(Boolean);
+  if (entries.length > 1) notes.unshift(`${entries.length} Buchungen`);
+  if (open.length) notes.push("Clock-out fehlt");
+  return {
+    type: open.length ? "Offen" : "Arbeit",
+    start: entries.map(item => item.start || "–").join(" / "),
+    end: entries.map(item => item.end || "läuft").join(" / "),
+    breakMinutes: closed.reduce((sum, item) => sum + entryBreak(item), 0),
+    netMinutes: closed.reduce((sum, item) => sum + durationMinutes(item), 0),
+    note: [...new Set(notes)].join(" · "),
+    entryCount: entries.length,
+    openCount: open.length,
+  };
+}
+
+function externalEmployerName(value) {
+  const name = normalizeText(value);
+  return !name || /aora/i.test(name) ? "Arbeitgeber" : name;
+}
+
+export function buildCanonicalSnapshot({ state, organization, employee, location, locationId, from, to, generatedAt = new Date().toISOString() }) {
+  const employeeId = String(employee.id);
+  const entries = (state.timeEntries || []).filter(item => String(item.employeeId ?? item.employee_id) === employeeId && entryDate(item) >= from && entryDate(item) <= to);
+  const shifts = (state.shifts || []).filter(item => String(item.employeeId ?? item.employee_id) === employeeId && String(item.date) >= from && String(item.date) <= to);
+  const leaves = (state.leaveRequests || []).filter(item => {
+    if (String(item.employeeId ?? item.employee_id) !== employeeId || String(item.status || "").toLowerCase() === "rejected") return false;
+    const range = leaveRange(item);
+    return range.start <= to && range.end >= from;
+  });
+  const dailyTarget = Math.round((Number(employee.weeklyHours || employee.contractHours || employee.weeklyTargetHours || 40) * 60) / 5);
+  const rows = enumerateDates(from, to).map(date => {
+    const dateEntries = entries.filter(item => entryDate(item) === date);
+    const dateShifts = shifts.filter(item => String(item.date) === date);
+    const leave = leaves.find(item => {
+      const range = leaveRange(item);
+      return range.start <= date && range.end >= date;
+    });
+    if (leave) {
+      return {
+        date,
+        type: leaveType(leave),
+        start: "",
+        end: "",
+        breakMinutes: 0,
+        netMinutes: dailyTarget,
+        note: normalizeText(leave.note || leave.reason || "Genehmigte Abwesenheit"),
+        entryCount: 0,
+      };
+    }
+    if (dateEntries.length) return { date, ...aggregateDayEntries(dateEntries) };
+    if (dateShifts.length) {
+      const sorted = dateShifts.slice().sort((a, b) => String(a.start || "").localeCompare(String(b.start || "")));
+      return {
+        date,
+        type: "Fehlzeit",
+        start: sorted.map(item => normalizeText(item.start) || "–").join(" / "),
+        end: sorted.map(item => normalizeText(item.end) || "–").join(" / "),
+        breakMinutes: sorted.reduce((sum, item) => sum + Math.max(0, Number(item.breakMinutes) || 0), 0),
+        netMinutes: 0,
+        note: sorted.length > 1 ? `Keine Zeitbuchung · ${sorted.length} geplante Schichten` : "Keine Zeitbuchung",
+        entryCount: 0,
+      };
+    }
+    return null;
+  }).filter(Boolean);
+  const workedMinutes = rows.reduce((sum, row) => sum + (["Arbeit", "Offen"].includes(row.type) ? Number(row.netMinutes || 0) : 0), 0);
+  const creditedMinutes = rows.reduce((sum, row) => sum + (["Urlaub", "Krankheit", "Abwesenheit"].includes(row.type) ? Number(row.netMinutes || 0) : 0), 0);
+  const plannedMinutes = shifts.reduce((sum, item) => sum + durationMinutes(item), 0);
+  return {
+    schemaVersion: 3,
+    generatedAt,
+    organization: { id: organization.id, name: externalEmployerName(state.company?.name || organization.name) },
+    location: {
+      id: locationId,
+      name: normalizeText(location?.name || "Standort"),
+      address: normalizeText(location?.address || location?.street || ""),
+      city: normalizeText(location?.city || ""),
+      postalCode: normalizeText(location?.postalCode || location?.zip || ""),
+      country: normalizeText(location?.country || "DE"),
+    },
+    employee: {
+      id: employeeId,
+      name: normalizeText(employee.name || "Mitarbeiter/in"),
+      personnelNumber: normalizeText(employee.personnelNumber || employee.employeeNumber || employee.staffNumber || `A-${employeeId.slice(-5).toUpperCase()}`),
+      position: normalizeText(employee.position || employee.jobTitle || employee.role || "Mitarbeiter/in"),
+      contract: normalizeText(employee.employmentType || employee.contractType || "Beschäftigt"),
+      weeklyHours: Number(employee.weeklyHours || employee.contractHours || 40),
+    },
+    period: { from, to },
+    rows,
+    totals: {
+      plannedMinutes,
+      workedMinutes,
+      creditedMinutes,
+      totalMinutes: workedMinutes + creditedMinutes,
+      differenceMinutes: workedMinutes + creditedMinutes - plannedMinutes,
+      workDays: rows.filter(row => ["Arbeit", "Offen"].includes(row.type) && Number(row.netMinutes || 0) > 0).length,
+      openDays: rows.filter(row => ["Offen", "Fehlzeit"].includes(row.type)).length,
+      entryCount: entries.length,
+    },
+  };
+}
+
+export function canonicalJsonValue(value) {
+  if (Array.isArray(value)) return value.map(canonicalJsonValue);
+  if (value && typeof value === "object") {
+    return Object.keys(value).sort().reduce((result, key) => {
+      result[key] = canonicalJsonValue(value[key]);
+      return result;
+    }, {});
+  }
+  return value;
+}
+
+export function stableStringify(value) {
+  return JSON.stringify(canonicalJsonValue(value));
+}

--- a/aora-v8-final/supabase/functions/aora-v8-timesheet-document-signing-sync/index.ts
+++ b/aora-v8-final/supabase/functions/aora-v8-timesheet-document-signing-sync/index.ts
@@ -1,0 +1,258 @@
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+import { createClient } from "npm:@supabase/supabase-js@2.57.4";
+import { buildCanonicalSnapshot, stableStringify } from "./aggregation.mjs";
+
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
+const SERVICE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+const service = createClient(SUPABASE_URL, SERVICE_KEY, { auth: { persistSession: false, autoRefreshToken: false } });
+const CORE_FUNCTION = "aora-v8-timesheet-document-signing";
+const WORKFLOW_VERSION = "2026-08-04.2-sync";
+const DEFAULT_ORIGIN = "https://dopamine-mobins-projects-4f428afa.vercel.app";
+const TEAM_SUFFIX = "-mobins-projects-4f428afa.vercel.app";
+const MAX_BODY_BYTES = 1_500_000;
+const EXACT_ORIGINS = new Set([
+  DEFAULT_ORIGIN,
+  "https://dopamine-blond.vercel.app",
+  "https://dopamine-git-main-mobins-projects-4f428afa.vercel.app",
+  "https://aora-v8-hardening.vercel.app",
+  "https://aora-v8-final.vercel.app",
+  "https://aora-workforce.vercel.app",
+]);
+
+function localHost(hostname: string) {
+  const host = hostname.replace(/^\[|\]$/g, "").toLowerCase();
+  return ["localhost", "0.0.0.0", "::1"].includes(host) || /^127(?:\.\d{1,3}){3}$/.test(host);
+}
+
+function originAllowed(origin: string | null) {
+  if (!origin || origin === "null") return true;
+  try {
+    const parsed = new URL(origin);
+    return EXACT_ORIGINS.has(parsed.origin) ||
+      (parsed.protocol === "https:" && parsed.hostname.endsWith(TEAM_SUFFIX)) ||
+      (parsed.protocol === "http:" && localHost(parsed.hostname));
+  } catch {
+    return false;
+  }
+}
+
+function cors(origin: string | null) {
+  return {
+    "Access-Control-Allow-Origin": origin && originAllowed(origin) ? origin : DEFAULT_ORIGIN,
+    "Access-Control-Allow-Headers": "content-type",
+    "Access-Control-Allow-Methods": "POST,OPTIONS",
+    "Access-Control-Expose-Headers": "content-disposition,x-document-checksum,x-document-signed",
+    "Access-Control-Max-Age": "600",
+    "Cache-Control": "no-store",
+    "X-Content-Type-Options": "nosniff",
+    "Referrer-Policy": "no-referrer",
+    Vary: "Origin",
+  };
+}
+
+function json(body: unknown, status = 200, origin: string | null = null) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...cors(origin), "Content-Type": "application/json; charset=utf-8" },
+  });
+}
+
+function fail(message: string, status = 400): never {
+  throw Object.assign(new Error(message), { status });
+}
+
+function normalizeState(state: any) {
+  for (const key of ["admins", "employees", "locations", "timeEntries", "shifts", "leaveRequests"]) {
+    if (!Array.isArray(state?.[key])) state[key] = [];
+  }
+  return state;
+}
+
+function safeDate(value: unknown) {
+  const date = String(value || "");
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) fail("Ungültiges Datum.", 400);
+  return date;
+}
+
+async function sha256Text(value: string) {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value));
+  return Array.from(new Uint8Array(digest)).map(part => part.toString(16).padStart(2, "0")).join("");
+}
+
+async function context(token: string) {
+  if (token.length !== 64) fail("Sitzungstoken fehlt.", 401);
+  const { data: sessions, error } = await service.rpc("validate_demo_session", { p_token: token });
+  if (error || !sessions?.length) fail("Sitzung ist ungültig oder abgelaufen.", 401);
+  const session = sessions[0];
+  const { data: organization } = await service.from("organizations").select("id,slug,name,status,timezone").eq("id", session.organization_id).eq("status", "active").single();
+  if (!organization) fail("Organisation ist nicht aktiv.", 403);
+  const { data: snapshot } = await service.from("workspace_snapshots").select("state,revision").eq("organization_id", organization.id).single();
+  if (!snapshot) fail("Arbeitsbereich wurde nicht gefunden.", 404);
+  const state = normalizeState(structuredClone(snapshot.state || {}));
+  const admin = session.role === "admin"
+    ? state.admins.find((item: any) => item.id === session.subject_id && item.active !== false && item.status !== "revoked")
+    : null;
+  const employee = session.role === "employee"
+    ? state.employees.find((item: any) => item.id === session.subject_id && item.active !== false && item.status !== "revoked")
+    : null;
+  const accessRole = admin ? (admin.scope === "owner" ? "owner" : "manager") : (employee ? "employee" : session.role);
+  let locationIds: string[] = [];
+  if (accessRole === "owner") locationIds = state.locations.filter((item: any) => item.active !== false).map((item: any) => String(item.id));
+  if (accessRole === "manager") {
+    const { data: rows } = await service.from("manager_location_access").select("location_id").eq("organization_id", organization.id).eq("manager_id", session.subject_id);
+    locationIds = (rows || []).map((row: any) => String(row.location_id));
+    if (!locationIds.length) locationIds = (admin?.locationIds || [admin?.locationId]).filter(Boolean).map(String);
+  }
+  return { session, organization, snapshot, state, accessRole, locationIds };
+}
+
+function requireManager(ctx: any) {
+  if (!["owner", "manager"].includes(ctx.accessRole)) fail("Manager-Zugang erforderlich.", 403);
+}
+
+function employeeById(ctx: any, employeeId: string) {
+  const employee = ctx.state.employees.find((item: any) => String(item.id) === employeeId && item.active !== false && item.status !== "revoked");
+  if (!employee) fail("Mitarbeiter wurde nicht gefunden.", 404);
+  const locationId = String(employee.locationId || employee.primaryLocationId || "");
+  if (ctx.accessRole === "manager" && !ctx.locationIds.includes(locationId)) fail("Kein Zugriff auf diesen Mitarbeiter.", 403);
+  return { employee, locationId };
+}
+
+function locationById(ctx: any, locationId: string) {
+  return ctx.state.locations.find((item: any) => String(item.id) === locationId) || { id: locationId, name: "Standort", address: "", city: "" };
+}
+
+async function audit(ctx: any, submissionId: string, action: string, payload: Record<string, unknown>) {
+  const { error } = await service.from("audit_logs").insert({
+    organization_id: ctx.organization.id,
+    id: crypto.randomUUID(),
+    action,
+    actor: ctx.session.subject_id,
+    actor_type: ctx.accessRole,
+    actor_id: ctx.session.subject_id,
+    entity: "timesheet_submission",
+    entity_type: "timesheet_submission",
+    entity_id: submissionId,
+    created_at: new Date().toISOString(),
+    payload,
+    metadata: { source: "timesheet-document-signing-sync", workflowVersion: WORKFLOW_VERSION },
+  });
+  if (error) console.warn("Timesheet sync audit write failed", error);
+}
+
+async function proxyToCore(text: string, origin: string | null) {
+  const upstream = await fetch(`${SUPABASE_URL}/functions/v1/${CORE_FUNCTION}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "text/plain;charset=UTF-8",
+      Authorization: `Bearer ${SERVICE_KEY}`,
+      apikey: SERVICE_KEY,
+    },
+    body: text,
+  });
+  const headers = new Headers(cors(origin));
+  for (const name of ["content-type", "content-disposition", "x-document-checksum", "x-document-signed"]) {
+    const value = upstream.headers.get(name);
+    if (value) headers.set(name, value);
+  }
+  return new Response(upstream.body, { status: upstream.status, headers });
+}
+
+Deno.serve(async (request: Request) => {
+  const origin = request.headers.get("origin");
+  if (request.method === "OPTIONS") return new Response("ok", { headers: cors(origin) });
+  if (request.method !== "POST") return json({ error: "Method not allowed" }, 405, origin);
+  if (!originAllowed(origin)) return json({ error: "Origin not allowed" }, 403, origin);
+  const text = await request.text();
+  if (new TextEncoder().encode(text).byteLength > MAX_BODY_BYTES) return json({ error: "Request too large" }, 413, origin);
+  let body: any;
+  try { body = JSON.parse(text || "{}"); } catch { return json({ error: "Invalid request" }, 400, origin); }
+
+  if (String(body.action || "") !== "prepareTimesheet") {
+    try { return await proxyToCore(text, origin); }
+    catch (error) {
+      console.error("Timesheet core proxy failed", error);
+      return json({ error: "Arbeitszeitnachweis-Service ist vorübergehend nicht erreichbar." }, 503, origin);
+    }
+  }
+
+  try {
+    const ctx = await context(String(body.token || ""));
+    requireManager(ctx);
+    const employeeId = String(body.employeeId || "");
+    const from = safeDate(body.dateFrom);
+    const to = safeDate(body.dateTo);
+    if (from > to) fail("Der Beginn liegt nach dem Ende.", 400);
+    const { employee, locationId } = employeeById(ctx, employeeId);
+    const location = locationById(ctx, locationId);
+    const snapshot = buildCanonicalSnapshot({
+      state: ctx.state,
+      organization: ctx.organization,
+      employee,
+      location,
+      locationId,
+      from,
+      to,
+    });
+    const snapshotHash = await sha256Text(stableStringify(snapshot));
+    const period = `${from}:${to}`;
+    const { data: existing } = await service.from("timesheet_submissions").select("*").eq("organization_id", ctx.organization.id).eq("employee_id", employeeId).eq("period", period).maybeSingle();
+    if (existing?.status === "locked") fail("Die bestätigte Endfassung wurde bereits exportiert und ist unveränderbar. Für eine Korrektur muss ein neuer Zeitraum beziehungsweise ein dokumentierter Folgeprozess verwendet werden.", 409);
+    const version = Number(existing?.version || 0) + 1;
+    const record = {
+      organization_id: ctx.organization.id,
+      id: existing?.id || crypto.randomUUID(),
+      employee_id: employeeId,
+      location_id: locationId || null,
+      period,
+      date_from: from,
+      date_to: to,
+      status: "open",
+      version,
+      submitted_at: null,
+      approved_at: null,
+      locked_at: null,
+      sent_by: null,
+      sent_at: null,
+      approval_requested_at: null,
+      approval_requested_by: null,
+      employee_decision: null,
+      employee_decided_at: null,
+      employee_note: null,
+      signature_id: null,
+      document_signature_id: null,
+      snapshot_hash: snapshotHash,
+      signed_hash: null,
+      exported_at: null,
+      exported_by: null,
+      export_format: null,
+      export_checksum: null,
+      signed_exported_at: null,
+      signed_exported_by: null,
+      signed_export_checksum: null,
+      unsigned_exported_at: null,
+      unsigned_exported_by: null,
+      unsigned_export_checksum: null,
+      payload: { snapshot, workflowVersion: WORKFLOW_VERSION, sourceRevision: ctx.snapshot.revision },
+    };
+    const query = existing
+      ? service.from("timesheet_submissions").update(record).eq("organization_id", ctx.organization.id).eq("id", existing.id)
+      : service.from("timesheet_submissions").insert(record);
+    const { data: submission, error } = await query.select("*").single();
+    if (error) throw error;
+    await audit(ctx, submission.id, existing ? "TIMESHEET_DRAFT_REFRESHED" : "TIMESHEET_DRAFT_CREATED", {
+      employeeId,
+      from,
+      to,
+      version,
+      snapshotHash,
+      openDays: snapshot.totals.openDays,
+      entryCount: snapshot.totals.entryCount,
+      sourceRevision: ctx.snapshot.revision,
+    });
+    return json({ submission }, existing ? 200 : 201, origin);
+  } catch (error: any) {
+    console.error("Aora synchronized timesheet preparation failed", error);
+    return json({ error: error instanceof Error ? error.message : String(error) }, Number(error?.status || 500), origin);
+  }
+});

--- a/aora-v8-final/tests/time-workflow-sync-source.mjs
+++ b/aora-v8-final/tests/time-workflow-sync-source.mjs
@@ -33,16 +33,23 @@ for(const marker of ["aoraReportBuildPrintBundle(all)",'data-a="report-print-all
 for(const marker of ["buildCanonicalSnapshot","prepareTimesheet","TIMESHEET_DRAFT_REFRESHED","entryCount"]){
   assert.ok(edge.includes(marker),`missing synchronized edge marker: ${marker}`);
 }
-for(const marker of ["S.session=restore(accessRole)","callback.invitationId&&callback.token&&S.session","clearInvitationCallback();","await loadState();"]){
-  assert.ok(boot.includes(marker),`missing authenticated invitation-routing marker: ${marker}`);
+for(const marker of [
+  "function authenticatedSession(preferredRole)",
+  '[preferredRole,"owner","manager","employee","kiosk"]',
+  "const recovered=callback.invitationId&&callback.token?authenticatedSession(pathRole):null",
+  "setAccessRole(recovered.role)",
+  "clearInvitationCallback(recovered.role)",
+  'history.replaceState({},"",accessPath(accessRole))'
+]){
+  assert.ok(boot.includes(marker),`missing cross-role invitation-session marker: ${marker}`);
 }
 assert.ok(
-  boot.indexOf("S.session=restore(accessRole)")<boot.indexOf("redirectInvitationToCanonicalOrigin(callback)"),
-  "an authenticated session must be restored before an invitation callback can redirect or replace the active admin view"
+  boot.indexOf("const recovered=callback.invitationId&&callback.token?authenticatedSession(pathRole):null")<boot.indexOf("redirectInvitationToCanonicalOrigin(callback)"),
+  "an authenticated session from any valid role must be recovered before an invitation callback can redirect"
 );
 assert.ok(
-  boot.indexOf("callback.invitationId&&callback.token&&S.session")<boot.indexOf("renderInvitationSetup(info,callback.invitationId,callback.token)"),
-  "active sessions must clear invitation secrets and load the workspace before invitation activation is rendered"
+  boot.indexOf("if(recovered)")<boot.indexOf("renderInvitationSetup(info,callback.invitationId,callback.token)"),
+  "an authenticated session must restore its canonical role route before invitation activation can render"
 );
 
 const twoSegments=[
@@ -99,4 +106,4 @@ assert.equal(openSnapshot.rows[0].netMinutes,240,"completed segments must remain
 assert.equal(openSnapshot.totals.workedMinutes,240);
 assert.equal(openSnapshot.totals.openDays,1);
 
-console.log("Time workflow synchronization contract passed: Freigaben navigation, one approvals UI, multi-entry daily aggregation, matching live report semantics, distinct print routes, authenticated invitation routing and synchronized snapshots.");
+console.log("Time workflow synchronization contract passed: Freigaben navigation, one approvals UI, multi-entry daily aggregation, matching live report semantics, distinct print routes, cross-role invitation session recovery and synchronized snapshots.");

--- a/aora-v8-final/tests/time-workflow-sync-source.mjs
+++ b/aora-v8-final/tests/time-workflow-sync-source.mjs
@@ -18,10 +18,17 @@ const [index,prepareSync,reportsSync,reportPrintFix,boot,identityHardening,edge]
 
 assert.ok(!index.includes("timesheet-approval.js"),"obsolete reusable-signature approvals module must not be loaded");
 assert.ok(!index.includes("timesheet-approval.css"),"obsolete approvals stylesheet must not be loaded");
-for(const marker of ["time-workflow-prepare-sync.js?v=835","reports-sync.js?v=835","timesheet-document-signing.js?v=833"]){
+for(const marker of ["time-workflow-prepare-sync.js?v=837","reports-sync.js?v=835","timesheet-document-signing.js?v=833"]){
   assert.ok(index.includes(marker),`missing synchronized workflow asset: ${marker}`);
 }
-assert.ok(index.indexOf("time-workflow-prepare-sync.js")<index.indexOf("timesheet-document-signing.js"),"prepare interception must load before document signing UI");
+assert.ok(
+  index.indexOf("modules/admin.js")<index.indexOf("time-workflow-prepare-sync.js"),
+  "Freigaben navigation must load after managerNav and ownerNav are defined"
+);
+assert.ok(
+  index.indexOf("time-workflow-prepare-sync.js")<index.indexOf("timesheet-document-signing.js"),
+  "prepare interception must load before document signing UI"
+);
 for(const marker of ["aora-v8-timesheet-document-signing-sync","stopImmediatePropagation","aora:timesheet-prepared","addApprovalsNavigation","managerNav","ownerNav"]){
   assert.ok(prepareSync.includes(marker),`missing prepare/navigation sync marker: ${marker}`);
 }
@@ -119,4 +126,4 @@ assert.equal(openSnapshot.rows[0].netMinutes,240,"completed segments must remain
 assert.equal(openSnapshot.totals.workedMinutes,240);
 assert.equal(openSnapshot.totals.openDays,1);
 
-console.log("Time workflow synchronization contract passed: Freigaben navigation without premature rendering, protected admin session restoration, one approvals UI, multi-entry daily aggregation, matching live report semantics, distinct print routes, cross-role invitation session recovery and synchronized snapshots.");
+console.log("Time workflow synchronization contract passed: dependency-safe Freigaben navigation without premature rendering, protected admin session restoration, one approvals UI, multi-entry daily aggregation, matching live report semantics, distinct print routes, cross-role invitation session recovery and synchronized snapshots.");

--- a/aora-v8-final/tests/time-workflow-sync-source.mjs
+++ b/aora-v8-final/tests/time-workflow-sync-source.mjs
@@ -6,12 +6,13 @@ import { aggregateDayEntries, buildCanonicalSnapshot } from "../supabase/functio
 
 const root=resolve(dirname(fileURLToPath(import.meta.url)),"..");
 const read=path=>readFile(resolve(root,path),"utf8");
-const [index,prepareSync,reportsSync,reportPrintFix,boot,edge]=await Promise.all([
+const [index,prepareSync,reportsSync,reportPrintFix,boot,identityHardening,edge]=await Promise.all([
   read("app/index.html"),
   read("app/modules/time-workflow-prepare-sync.js"),
   read("app/modules/reports-sync.js"),
   read("app/modules/reports-pdf-mobile-fix.js"),
   read("app/modules/boot.js"),
+  read("app/modules/identity-hardening.js"),
   read("supabase/functions/aora-v8-timesheet-document-signing-sync/index.ts")
 ]);
 
@@ -24,6 +25,18 @@ assert.ok(index.indexOf("time-workflow-prepare-sync.js")<index.indexOf("timeshee
 for(const marker of ["aora-v8-timesheet-document-signing-sync","stopImmediatePropagation","aora:timesheet-prepared","addApprovalsNavigation","managerNav","ownerNav"]){
   assert.ok(prepareSync.includes(marker),`missing prepare/navigation sync marker: ${marker}`);
 }
+assert.ok(!prepareSync.includes('document.addEventListener("DOMContentLoaded"'),"Freigaben navigation must not trigger an admin render during boot");
+assert.ok(
+  prepareSync.indexOf("addApprovalsNavigation();")<prepareSync.indexOf('document.addEventListener("click"'),
+  "Freigaben navigation must register synchronously before boot without an extra render"
+);
+for(const marker of ["!S.state||!Array.isArray(S.state.admins)",'typeof renderLoading==="function"',"const admin=currentAdmin()"]){
+  assert.ok(identityHardening.includes(marker),`missing pre-state admin-session guard: ${marker}`);
+}
+assert.ok(
+  identityHardening.indexOf("!S.state||!Array.isArray(S.state.admins)")<identityHardening.indexOf("const admin=currentAdmin()"),
+  "identity hardening must not invalidate a restored session before workspace state arrives"
+);
 for(const marker of ["alle Buchungen zusammengeführt","Live-Auswertung","Vollständig","Freigaben"]){
   assert.ok(reportsSync.includes(marker),`missing report synchronization marker: ${marker}`);
 }
@@ -106,4 +119,4 @@ assert.equal(openSnapshot.rows[0].netMinutes,240,"completed segments must remain
 assert.equal(openSnapshot.totals.workedMinutes,240);
 assert.equal(openSnapshot.totals.openDays,1);
 
-console.log("Time workflow synchronization contract passed: Freigaben navigation, one approvals UI, multi-entry daily aggregation, matching live report semantics, distinct print routes, cross-role invitation session recovery and synchronized snapshots.");
+console.log("Time workflow synchronization contract passed: Freigaben navigation without premature rendering, protected admin session restoration, one approvals UI, multi-entry daily aggregation, matching live report semantics, distinct print routes, cross-role invitation session recovery and synchronized snapshots.");

--- a/aora-v8-final/tests/time-workflow-sync-source.mjs
+++ b/aora-v8-final/tests/time-workflow-sync-source.mjs
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { aggregateDayEntries, buildCanonicalSnapshot } from "../supabase/functions/aora-v8-timesheet-document-signing-sync/aggregation.mjs";
+
+const root=resolve(dirname(fileURLToPath(import.meta.url)),"..");
+const read=path=>readFile(resolve(root,path),"utf8");
+const [index,prepareSync,reportsSync,edge]=await Promise.all([
+  read("app/index.html"),
+  read("app/modules/time-workflow-prepare-sync.js"),
+  read("app/modules/reports-sync.js"),
+  read("supabase/functions/aora-v8-timesheet-document-signing-sync/index.ts")
+]);
+
+assert.ok(!index.includes("timesheet-approval.js"),"obsolete reusable-signature approvals module must not be loaded");
+assert.ok(!index.includes("timesheet-approval.css"),"obsolete approvals stylesheet must not be loaded");
+for(const marker of ["time-workflow-prepare-sync.js?v=835","reports-sync.js?v=835","timesheet-document-signing.js?v=833"]){
+  assert.ok(index.includes(marker),`missing synchronized workflow asset: ${marker}`);
+}
+assert.ok(index.indexOf("time-workflow-prepare-sync.js")<index.indexOf("timesheet-document-signing.js"),"prepare interception must load before document signing UI");
+for(const marker of ["aora-v8-timesheet-document-signing-sync","stopImmediatePropagation","aora:timesheet-prepared"]){
+  assert.ok(prepareSync.includes(marker),`missing prepare sync marker: ${marker}`);
+}
+for(const marker of ["alle Buchungen zusammengeführt","Live-Auswertung","Vollständig","Freigaben"]){
+  assert.ok(reportsSync.includes(marker),`missing report synchronization marker: ${marker}`);
+}
+for(const marker of ["buildCanonicalSnapshot","prepareTimesheet","TIMESHEET_DRAFT_REFRESHED","entryCount"]){
+  assert.ok(edge.includes(marker),`missing synchronized edge marker: ${marker}`);
+}
+
+const twoSegments=[
+  {date:"2026-08-04",start:"08:00",end:"12:00",breakMinutes:0,status:"closed"},
+  {date:"2026-08-04",start:"14:00",end:"18:00",breakMinutes:30,status:"closed"}
+];
+const day=aggregateDayEntries(twoSegments);
+assert.equal(day.type,"Arbeit");
+assert.equal(day.entryCount,2);
+assert.equal(day.start,"08:00 / 14:00");
+assert.equal(day.end,"12:00 / 18:00");
+assert.equal(day.netMinutes,450);
+assert.equal(day.breakMinutes,30);
+assert.match(day.note,/2 Buchungen/);
+
+const state={
+  company:{name:"Test Arbeitgeber"},
+  timeEntries:twoSegments.map((entry,index)=>({...entry,id:`entry-${index}`,employeeId:"employee-1",locationId:"location-1"})),
+  shifts:[{id:"shift-1",employeeId:"employee-1",locationId:"location-1",date:"2026-08-04",start:"08:00",end:"18:00",breakMinutes:60}],
+  leaveRequests:[]
+};
+const snapshot=buildCanonicalSnapshot({
+  state,
+  organization:{id:"organization-1",name:"Test Arbeitgeber"},
+  employee:{id:"employee-1",name:"Test Employee",weeklyHours:40,locationId:"location-1"},
+  location:{id:"location-1",name:"Testfiliale"},
+  locationId:"location-1",
+  from:"2026-08-04",
+  to:"2026-08-04",
+  generatedAt:"2026-08-04T12:00:00.000Z"
+});
+assert.equal(snapshot.schemaVersion,3);
+assert.equal(snapshot.rows.length,1);
+assert.equal(snapshot.rows[0].entryCount,2);
+assert.equal(snapshot.totals.entryCount,2);
+assert.equal(snapshot.totals.workedMinutes,450);
+assert.equal(snapshot.totals.totalMinutes,450);
+assert.equal(snapshot.totals.plannedMinutes,540);
+assert.equal(snapshot.totals.differenceMinutes,-90);
+assert.equal(snapshot.totals.openDays,0);
+
+const openSnapshot=buildCanonicalSnapshot({
+  state:{...state,timeEntries:[state.timeEntries[0],{id:"entry-open",employeeId:"employee-1",locationId:"location-1",date:"2026-08-04",start:"14:00",end:"",status:"live"}]},
+  organization:{id:"organization-1",name:"Test Arbeitgeber"},
+  employee:{id:"employee-1",name:"Test Employee",weeklyHours:40,locationId:"location-1"},
+  location:{id:"location-1",name:"Testfiliale"},
+  locationId:"location-1",
+  from:"2026-08-04",
+  to:"2026-08-04",
+  generatedAt:"2026-08-04T12:00:00.000Z"
+});
+assert.equal(openSnapshot.rows[0].type,"Offen");
+assert.equal(openSnapshot.rows[0].netMinutes,240,"completed segments must remain counted while another segment is open");
+assert.equal(openSnapshot.totals.workedMinutes,240);
+assert.equal(openSnapshot.totals.openDays,1);
+
+console.log("Time workflow synchronization contract passed: one approvals UI, multi-entry daily aggregation, matching live report semantics and synchronized snapshots.");

--- a/aora-v8-final/tests/time-workflow-sync-source.mjs
+++ b/aora-v8-final/tests/time-workflow-sync-source.mjs
@@ -6,11 +6,12 @@ import { aggregateDayEntries, buildCanonicalSnapshot } from "../supabase/functio
 
 const root=resolve(dirname(fileURLToPath(import.meta.url)),"..");
 const read=path=>readFile(resolve(root,path),"utf8");
-const [index,prepareSync,reportsSync,reportPrintFix,edge]=await Promise.all([
+const [index,prepareSync,reportsSync,reportPrintFix,boot,edge]=await Promise.all([
   read("app/index.html"),
   read("app/modules/time-workflow-prepare-sync.js"),
   read("app/modules/reports-sync.js"),
   read("app/modules/reports-pdf-mobile-fix.js"),
+  read("app/modules/boot.js"),
   read("supabase/functions/aora-v8-timesheet-document-signing-sync/index.ts")
 ]);
 
@@ -32,6 +33,17 @@ for(const marker of ["aoraReportBuildPrintBundle(all)",'data-a="report-print-all
 for(const marker of ["buildCanonicalSnapshot","prepareTimesheet","TIMESHEET_DRAFT_REFRESHED","entryCount"]){
   assert.ok(edge.includes(marker),`missing synchronized edge marker: ${marker}`);
 }
+for(const marker of ["S.session=restore(accessRole)","callback.invitationId&&callback.token&&S.session","clearInvitationCallback();","await loadState();"]){
+  assert.ok(boot.includes(marker),`missing authenticated invitation-routing marker: ${marker}`);
+}
+assert.ok(
+  boot.indexOf("S.session=restore(accessRole)")<boot.indexOf("redirectInvitationToCanonicalOrigin(callback)"),
+  "an authenticated session must be restored before an invitation callback can redirect or replace the active admin view"
+);
+assert.ok(
+  boot.indexOf("callback.invitationId&&callback.token&&S.session")<boot.indexOf("renderInvitationSetup(info,callback.invitationId,callback.token)"),
+  "active sessions must clear invitation secrets and load the workspace before invitation activation is rendered"
+);
 
 const twoSegments=[
   {date:"2026-08-04",start:"08:00",end:"12:00",breakMinutes:0,status:"closed"},
@@ -87,4 +99,4 @@ assert.equal(openSnapshot.rows[0].netMinutes,240,"completed segments must remain
 assert.equal(openSnapshot.totals.workedMinutes,240);
 assert.equal(openSnapshot.totals.openDays,1);
 
-console.log("Time workflow synchronization contract passed: Freigaben navigation, one approvals UI, multi-entry daily aggregation, matching live report semantics, distinct print routes and synchronized snapshots.");
+console.log("Time workflow synchronization contract passed: Freigaben navigation, one approvals UI, multi-entry daily aggregation, matching live report semantics, distinct print routes, authenticated invitation routing and synchronized snapshots.");

--- a/aora-v8-final/tests/time-workflow-sync-source.mjs
+++ b/aora-v8-final/tests/time-workflow-sync-source.mjs
@@ -6,10 +6,11 @@ import { aggregateDayEntries, buildCanonicalSnapshot } from "../supabase/functio
 
 const root=resolve(dirname(fileURLToPath(import.meta.url)),"..");
 const read=path=>readFile(resolve(root,path),"utf8");
-const [index,prepareSync,reportsSync,edge]=await Promise.all([
+const [index,prepareSync,reportsSync,reportPrintFix,edge]=await Promise.all([
   read("app/index.html"),
   read("app/modules/time-workflow-prepare-sync.js"),
   read("app/modules/reports-sync.js"),
+  read("app/modules/reports-pdf-mobile-fix.js"),
   read("supabase/functions/aora-v8-timesheet-document-signing-sync/index.ts")
 ]);
 
@@ -19,11 +20,14 @@ for(const marker of ["time-workflow-prepare-sync.js?v=835","reports-sync.js?v=83
   assert.ok(index.includes(marker),`missing synchronized workflow asset: ${marker}`);
 }
 assert.ok(index.indexOf("time-workflow-prepare-sync.js")<index.indexOf("timesheet-document-signing.js"),"prepare interception must load before document signing UI");
-for(const marker of ["aora-v8-timesheet-document-signing-sync","stopImmediatePropagation","aora:timesheet-prepared"]){
-  assert.ok(prepareSync.includes(marker),`missing prepare sync marker: ${marker}`);
+for(const marker of ["aora-v8-timesheet-document-signing-sync","stopImmediatePropagation","aora:timesheet-prepared","addApprovalsNavigation","managerNav","ownerNav"]){
+  assert.ok(prepareSync.includes(marker),`missing prepare/navigation sync marker: ${marker}`);
 }
 for(const marker of ["alle Buchungen zusammengeführt","Live-Auswertung","Vollständig","Freigaben"]){
   assert.ok(reportsSync.includes(marker),`missing report synchronization marker: ${marker}`);
+}
+for(const marker of ["aoraReportBuildPrintBundle(all)",'data-a="report-print-all"',"printVisibleReport"]){
+  assert.ok(reportPrintFix.includes(marker),`missing report print routing marker: ${marker}`);
 }
 for(const marker of ["buildCanonicalSnapshot","prepareTimesheet","TIMESHEET_DRAFT_REFRESHED","entryCount"]){
   assert.ok(edge.includes(marker),`missing synchronized edge marker: ${marker}`);
@@ -83,4 +87,4 @@ assert.equal(openSnapshot.rows[0].netMinutes,240,"completed segments must remain
 assert.equal(openSnapshot.totals.workedMinutes,240);
 assert.equal(openSnapshot.totals.openDays,1);
 
-console.log("Time workflow synchronization contract passed: one approvals UI, multi-entry daily aggregation, matching live report semantics and synchronized snapshots.");
+console.log("Time workflow synchronization contract passed: Freigaben navigation, one approvals UI, multi-entry daily aggregation, matching live report semantics, distinct print routes and synchronized snapshots.");

--- a/aora-v8-final/tests/time-workflow-sync-source.mjs
+++ b/aora-v8-final/tests/time-workflow-sync-source.mjs
@@ -44,7 +44,7 @@ for(const marker of [
   assert.ok(boot.includes(marker),`missing cross-role invitation-session marker: ${marker}`);
 }
 assert.ok(
-  boot.indexOf("const recovered=callback.invitationId&&callback.token?authenticatedSession(pathRole):null")<boot.indexOf("redirectInvitationToCanonicalOrigin(callback)"),
+  boot.indexOf("const recovered=callback.invitationId&&callback.token?authenticatedSession(pathRole):null")<boot.indexOf("if(redirectInvitationToCanonicalOrigin(callback))return"),
   "an authenticated session from any valid role must be recovered before an invitation callback can redirect"
 );
 assert.ok(


### PR DESCRIPTION
## What changed
- removes the obsolete reusable-signature approvals module that called a non-deployed Edge Function
- keeps the document-scoped Freigaben workflow as the only approvals UI
- prepares official timesheet snapshots through a synchronized Edge Function
- aggregates every clock segment on the same day instead of showing only the first entry
- aligns live Bericht totals and status semantics with Stempeluhr/Korrektur data
- clearly separates a live completeness report from a digitally approved employee document

## Verification
- new deterministic multi-entry aggregation regression test
- existing production build/source gates
- existing Playwright document-signing flow
- staging Edge Function deployed as `aora-v8-timesheet-document-signing-sync`