### PR TITLE
Remove Berichte section and run full navigation QA

### DIFF
--- a/aora-v8-final/app/index.html
+++ b/aora-v8-final/app/index.html
@@ -50,6 +50,7 @@
 <script src="modules/employee.js?v=804" defer></script>
 <script src="modules/employee-hardening.js?v=819" defer></script>
 <script src="modules/admin.js?v=818" defer></script>
+<script src="modules/remove-reports-section.js?v=845" defer></script>
 <script src="modules/identity-hardening.js?v=809" defer></script>
 <script src="modules/admin-metrics-hardening.js?v=808" defer></script>
 <script src="modules/owner-routing.js?v=805" defer></script>

--- a/aora-v8-final/app/modules/remove-reports-section.js
+++ b/aora-v8-final/app/modules/remove-reports-section.js
@@ -1,0 +1,21 @@
+"use strict";
+
+const REPORTS_VIEW_ID="reports";
+
+function removeReportsNavigationEntry(navigation){
+  if(!Array.isArray(navigation))return;
+  for(let index=navigation.length-1;index>=0;index-=1){
+    if(navigation[index]?.[0]===REPORTS_VIEW_ID)navigation.splice(index,1);
+  }
+}
+
+removeReportsNavigationEntry(managerNav);
+removeReportsNavigationEntry(ownerNav);
+
+const renderAdminWithoutReports=renderAdmin;
+renderAdmin=function(){
+  if(S.adminView===REPORTS_VIEW_ID){
+    S.adminView=isOwner()?"owner-overview":"overview";
+  }
+  return renderAdminWithoutReports();
+};

--- a/aora-v8-final/playwright.config.mjs
+++ b/aora-v8-final/playwright.config.mjs
@@ -45,7 +45,7 @@ export default defineConfig({
     {
       name:"chromium",
       dependencies:["mobile-layout"],
-      testMatch:/aora-(accessibility|four-role|unified-login|time-correction-clock-hub)\.spec\.mjs/,
+      testMatch:/aora-(accessibility|four-role|unified-login|time-correction-clock-hub|navigation-qa)\.spec\.mjs/,
       use:desktop
     },
     {

--- a/aora-v8-final/tests/aora-navigation-qa.spec.mjs
+++ b/aora-v8-final/tests/aora-navigation-qa.spec.mjs
@@ -1,0 +1,70 @@
+import { test, expect } from "@playwright/test";
+
+const workspace=process.env.AORA_WORKSPACE_SLUG;
+const required=name=>{const value=process.env[name];if(!value)throw new Error(`Missing CI value: ${name}`);return value};
+
+async function login(page,role,email,password){
+  const route=role==="owner"?"/inhaber/":role==="manager"?"/arbeitgeber/":"/arbeitnehmer/";
+  await page.goto(`${route}?workspace=${encodeURIComponent(workspace)}`);
+  await page.locator('input[name="email"]').fill(email);
+  await page.locator('input[name="password"]').fill(password);
+  await page.locator('#password-login button[type="submit"]').click();
+  await expect(page.locator(role==="employee"?".employee-app":".admin-app")).toBeVisible({timeout:30000});
+}
+
+function collectRuntimeErrors(page){
+  const errors=[];
+  page.on("pageerror",error=>errors.push(error.message));
+  return errors;
+}
+
+async function traverseAdminViews(page,views){
+  await expect(page.locator('.admin-nav [data-view="reports"]')).toHaveCount(0);
+  await expect(page.getByRole("button",{name:"Berichte",exact:true})).toHaveCount(0);
+  for(const view of views){
+    const button=page.locator(`.admin-nav [data-a="admin-view"][data-view="${view}"]`);
+    await expect(button).toBeVisible();
+    await button.click();
+    await expect(page.locator(".admin-content")).toBeVisible();
+    await expect.poll(()=>page.evaluate(()=>S.adminView)).toBe(view);
+  }
+}
+
+test("all remaining role sections render without runtime errors and Berichte stays removed",async({browser,baseURL})=>{
+  const ownerContext=await browser.newContext({baseURL});
+  const owner=await ownerContext.newPage();
+  const ownerErrors=collectRuntimeErrors(owner);
+  await login(owner,"owner",required("AORA_OWNER_EMAIL"),required("AORA_OWNER_PASSWORD"));
+  await traverseAdminViews(owner,["owner-overview","locations","managers","invitations","operations","settings"]);
+  await owner.evaluate(()=>{S.adminView="reports";renderAdmin()});
+  await expect.poll(()=>owner.evaluate(()=>S.adminView)).toBe("owner-overview");
+  await expect(owner.locator('.admin-nav [data-view="reports"]')).toHaveCount(0);
+  expect(ownerErrors).toEqual([]);
+
+  const managerContext=await browser.newContext({baseURL});
+  const manager=await managerContext.newPage();
+  const managerErrors=collectRuntimeErrors(manager);
+  await login(manager,"manager",required("AORA_MANAGER_EMAIL"),required("AORA_MANAGER_PASSWORD"));
+  await traverseAdminViews(manager,["overview","schedule","time","leave","employees","news","kiosk","settings"]);
+  await manager.evaluate(()=>{S.adminView="reports";renderAdmin()});
+  await expect.poll(()=>manager.evaluate(()=>S.adminView)).toBe("overview");
+  await expect(manager.locator('.admin-nav [data-view="reports"]')).toHaveCount(0);
+  expect(managerErrors).toEqual([]);
+
+  const employeeContext=await browser.newContext({baseURL});
+  const employee=await employeeContext.newPage();
+  const employeeErrors=collectRuntimeErrors(employee);
+  await login(employee,"employee",required("AORA_EMPLOYEE_EMAIL"),required("AORA_EMPLOYEE_PASSWORD"));
+  for(const view of ["home","calendar","time","leave","tasks","more"]){
+    const button=employee.locator(`[data-a="employee-view"][data-view="${view}"]`);
+    await expect(button).toBeVisible();
+    await button.click();
+    await expect.poll(()=>employee.evaluate(()=>S.employeeView)).toBe(view);
+    await expect(employee.locator(".employee-main")).toBeVisible();
+  }
+  expect(employeeErrors).toEqual([]);
+
+  await employeeContext.close();
+  await managerContext.close();
+  await ownerContext.close();
+});


### PR DESCRIPTION
Removes the Berichte navigation entry for owner and manager accounts, redirects stale report views to the correct overview, and adds browser QA that traverses every remaining owner, manager, and employee section while checking for runtime errors. The full Aora release gate, four-role flows, mobile checks, load smoke, and the new navigation test must pass before merge.