### PR TITLE
Traverse every rendered role section in QA

### DIFF
--- a/aora-v8-final/tests/aora-navigation-qa.spec.mjs
+++ b/aora-v8-final/tests/aora-navigation-qa.spec.mjs
@@ -19,9 +19,15 @@ function collectRuntimeErrors(page){
   return errors;
 }
 
-async function traverseAdminViews(page,views){
+async function traverseEveryAdminView(page){
+  const nav=page.locator('.admin-nav [data-a="admin-view"][data-view]');
+  const views=await nav.evaluateAll(nodes=>nodes.map(node=>node.getAttribute("data-view")).filter(Boolean));
+  expect(views.length).toBeGreaterThan(0);
+  expect(new Set(views).size).toBe(views.length);
+  expect(views).not.toContain("reports");
   await expect(page.locator('.admin-nav [data-view="reports"]')).toHaveCount(0);
   await expect(page.locator('.admin-nav').getByRole("button",{name:"Berichte",exact:true})).toHaveCount(0);
+
   for(const view of views){
     const button=page.locator(`.admin-nav [data-a="admin-view"][data-view="${view}"]`);
     await expect(button).toBeVisible();
@@ -32,18 +38,38 @@ async function traverseAdminViews(page,views){
       await expect(page.getByRole("heading",{name:"Stempeln, prüfen, ändern und abschließen."})).toBeVisible();
     }
     if(view==="compliance"){
-      await expect(page.getByRole("heading",{name:"Compliance, Exporte und Zeitkorrekturen"})).toBeVisible();
+      await expect(page.getByRole("heading",{name:"Prüfung, Exporte und Backup"})).toBeVisible();
+      await expect(page.getByRole("button",{name:"CSV Arbeitszeit"})).toBeVisible();
       await expect(page.locator(".compliance-alert")).toHaveCount(0);
     }
   }
+  return views;
 }
 
-test("all remaining role sections render without runtime errors and Berichte stays removed",async({browser,baseURL})=>{
+async function traverseEveryEmployeeView(page){
+  const nav=page.locator('.employee-bottom [data-a="employee-view"][data-view]');
+  const views=await nav.evaluateAll(nodes=>nodes.map(node=>node.getAttribute("data-view")).filter(Boolean));
+  expect(views.length).toBeGreaterThan(0);
+  expect(new Set(views).size).toBe(views.length);
+  for(const view of views){
+    const button=page.locator(`.employee-bottom [data-a="employee-view"][data-view="${view}"]`);
+    await expect(button).toBeVisible();
+    await button.click();
+    await expect.poll(()=>page.evaluate(()=>S.employeeView)).toBe(view);
+    await expect(page.locator(".employee-main")).toBeVisible();
+  }
+  return views;
+}
+
+test("every remaining role section renders without runtime errors and Berichte stays removed",async({browser,baseURL})=>{
   const ownerContext=await browser.newContext({baseURL});
   const owner=await ownerContext.newPage();
   const ownerErrors=collectRuntimeErrors(owner);
   await login(owner,"owner",required("AORA_OWNER_EMAIL"),required("AORA_OWNER_PASSWORD"));
-  await traverseAdminViews(owner,["owner-overview","locations","managers","invitations","operations","worktime","compliance","settings"]);
+  const ownerViews=await traverseEveryAdminView(owner);
+  expect(ownerViews).toContain("tasks");
+  expect(ownerViews).toContain("worktime");
+  expect(ownerViews).toContain("compliance");
   await owner.evaluate(()=>{S.adminView="reports";renderAdmin()});
   await expect.poll(()=>owner.evaluate(()=>S.adminView)).toBe("owner-overview");
   await expect(owner.locator('.admin-nav [data-view="reports"]')).toHaveCount(0);
@@ -53,7 +79,10 @@ test("all remaining role sections render without runtime errors and Berichte sta
   const manager=await managerContext.newPage();
   const managerErrors=collectRuntimeErrors(manager);
   await login(manager,"manager",required("AORA_MANAGER_EMAIL"),required("AORA_MANAGER_PASSWORD"));
-  await traverseAdminViews(manager,["overview","schedule","worktime","leave","employees","news","kiosk","compliance","settings"]);
+  const managerViews=await traverseEveryAdminView(manager);
+  expect(managerViews).toContain("tasks");
+  expect(managerViews).toContain("worktime");
+  expect(managerViews).toContain("compliance");
   await manager.evaluate(()=>{S.adminView="reports";renderAdmin()});
   await expect.poll(()=>manager.evaluate(()=>S.adminView)).toBe("overview");
   await expect(manager.locator('.admin-nav [data-view="reports"]')).toHaveCount(0);
@@ -63,13 +92,8 @@ test("all remaining role sections render without runtime errors and Berichte sta
   const employee=await employeeContext.newPage();
   const employeeErrors=collectRuntimeErrors(employee);
   await login(employee,"employee",required("AORA_EMPLOYEE_EMAIL"),required("AORA_EMPLOYEE_PASSWORD"));
-  for(const view of ["home","calendar","time","leave","tasks","more"]){
-    const button=employee.locator(`[data-a="employee-view"][data-view="${view}"]`);
-    await expect(button).toBeVisible();
-    await button.click();
-    await expect.poll(()=>employee.evaluate(()=>S.employeeView)).toBe(view);
-    await expect(employee.locator(".employee-main")).toBeVisible();
-  }
+  const employeeViews=await traverseEveryEmployeeView(employee);
+  for(const requiredView of ["home","calendar","time","leave","tasks","more"])expect(employeeViews).toContain(requiredView);
   expect(employeeErrors).toEqual([]);
 
   await employeeContext.close();


### PR DESCRIPTION
Makes the final navigation test discover and open every visible owner, manager, and employee section instead of relying on a stale hard-coded list. It explicitly covers the injected Aufgaben, Arbeitszeit, and Prüfung & Exporte sections, verifies the removed Berichte route stays unavailable, and checks browser console/page errors.