### PR TITLE
Match employee QA to visible production navigation

### DIFF
--- a/aora-v8-final/tests/aora-navigation-qa.spec.mjs
+++ b/aora-v8-final/tests/aora-navigation-qa.spec.mjs
@@ -93,7 +93,7 @@ test("every remaining role section renders without runtime errors and Berichte s
   const employeeErrors=collectRuntimeErrors(employee);
   await login(employee,"employee",required("AORA_EMPLOYEE_EMAIL"),required("AORA_EMPLOYEE_PASSWORD"));
   const employeeViews=await traverseEveryEmployeeView(employee);
-  for(const requiredView of ["home","calendar","time","leave","tasks","more"])expect(employeeViews).toContain(requiredView);
+  for(const requiredView of ["home","calendar","time","leave","more"])expect(employeeViews).toContain(requiredView);
   expect(employeeErrors).toEqual([]);
 
   await employeeContext.close();


### PR DESCRIPTION
Keeps the dynamic full-section browser traversal and removes one stale assumption: the current employee bottom navigation contains Start, Kalender, Zeiten, Urlaub, and Mehr; Aufgaben is not a separate bottom tab. All visible employee sections are still discovered and opened automatically.