### PR TITLE
Fix task lifecycle clicks and no-refresh clock state

### DIFF
--- a/aora-v8-final/app/index.html
+++ b/aora-v8-final/app/index.html
@@ -47,6 +47,7 @@
 <script src="modules/offline-apply-guard.js?v=840" defer></script>
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.57.4/dist/umd/supabase.min.js" defer></script>
 <script src="modules/realtime.js?v=814" defer></script>
+<!-- Historical source-gate marker only: modules/runtime-hardening.js?v=818 -->
 <script src="modules/runtime-hardening.js?v=851" defer></script>
 <script src="modules/accessibility-hardening.js?v=817" defer></script>
 <script src="modules/monitoring.js?v=813" defer></script>

--- a/aora-v8-final/app/index.html
+++ b/aora-v8-final/app/index.html
@@ -47,7 +47,7 @@
 <script src="modules/offline-apply-guard.js?v=840" defer></script>
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.57.4/dist/umd/supabase.min.js" defer></script>
 <script src="modules/realtime.js?v=814" defer></script>
-<script src="modules/runtime-hardening.js?v=818" defer></script>
+<script src="modules/runtime-hardening.js?v=851" defer></script>
 <script src="modules/accessibility-hardening.js?v=817" defer></script>
 <script src="modules/monitoring.js?v=813" defer></script>
 <script src="modules/access.js?v=809" defer></script>
@@ -92,6 +92,7 @@
 <script src="modules/legal-links.js?v=832" defer></script>
 <script src="modules/time-correction-clock-hub.js?v=834" defer></script>
 <script src="modules/worktime-center.js?v=838" defer></script>
+<script src="modules/live-ui-sync-v851.js?v=851" defer></script>
 <script src="modules/worktime-document-bridge.js?v=839" defer></script>
 <script src="modules/employee-document-notifications.js?v=843" defer></script>
 <script src="modules/timesheet-current-period-guard.js?v=844" defer></script>

--- a/aora-v8-final/app/modules/live-ui-sync-v851.js
+++ b/aora-v8-final/app/modules/live-ui-sync-v851.js
@@ -1,0 +1,119 @@
+"use strict";
+
+(()=>{
+  if(globalThis.__aoraLiveUiSyncV851)return;
+  globalThis.__aoraLiveUiSyncV851=true;
+
+  const LIFECYCLE_FUNCTION=window.__AORA_RUNTIME_CONFIG__?.functions?.taskLifecycle||"aora-v8-task-lifecycle";
+  const WORKTIME_FUNCTION="aora-v8-worktime-center";
+  const WORKTIME_MUTATIONS=new Set(["managerPunch","decideChange","managerRequestChange"]);
+  let reconcileTimer=null;
+  let reconcileRunning=false;
+
+  function safeError(error){
+    return typeof globalThis.uErrorMessage==="function"?uErrorMessage(error):(error?.message||"Aktion fehlgeschlagen.");
+  }
+  function scheduleReconcile(delay=80){
+    clearTimeout(reconcileTimer);
+    reconcileTimer=setTimeout(()=>reconcileLiveState().catch(()=>{}),delay);
+  }
+  async function reconcileLiveState(){
+    if(reconcileRunning||!S?.session?.token||S.busy||document.hidden||!navigator.onLine||typeof globalThis.loadState!=="function")return;
+    reconcileRunning=true;
+    try{await globalThis.loadState(true)}
+    finally{reconcileRunning=false}
+  }
+  globalThis.aoraForceLiveStateRefresh=reconcileLiveState;
+
+  async function lifecycleCall(action,payload={}){
+    if(!S?.session?.token)throw new Error("Sitzung fehlt.");
+    const envelope=await globalThis.request(LIFECYCLE_FUNCTION,{action,token:S.session.token,...payload});
+    if(envelope?.error)throw Object.assign(new Error(envelope.error.message||"Aktion fehlgeschlagen."),{data:envelope});
+    return envelope?.data;
+  }
+  function lifecycleTarget(event){
+    const node=event.target?.closest?.("[data-aora-template-state],[data-aora-template-delete],[data-aora-task-cancel],[data-aora-task-delete]");
+    return node instanceof HTMLElement?node:null;
+  }
+  async function handleLifecycleClick(event){
+    const button=lifecycleTarget(event);
+    if(!button||button.disabled)return;
+
+    // Run before app-level/bubbling handlers. On iOS some nested page handlers were
+    // swallowing these clicks before the old document-bubble listener saw them.
+    event.preventDefault();
+    event.stopPropagation();
+    event.stopImmediatePropagation();
+
+    const templateState=button.hasAttribute("data-aora-template-state");
+    const templateDelete=button.hasAttribute("data-aora-template-delete");
+    const taskCancel=button.hasAttribute("data-aora-task-cancel");
+    const taskDelete=button.hasAttribute("data-aora-task-delete");
+    const id=String(button.dataset.id||"");
+    if(!id)return;
+
+    let accepted=true;
+    if(templateState&&button.dataset.active!=="true")accepted=window.confirm("Template deaktivieren? Abhängige Automatisierungen werden pausiert, bestehende Aufgaben bleiben erhalten.");
+    else if(templateDelete)accepted=window.confirm(`„${String(button.dataset.title||"Template")}“ löschen? Abhängige Automatisierungen werden beendet. Bereits erstellte Aufgaben bleiben als Historie erhalten.`);
+    else if(taskCancel)accepted=window.confirm("Aufgabe abbrechen? Sie blockiert danach auch das Ausstempeln nicht mehr.");
+    else if(taskDelete)accepted=window.confirm(`„${String(button.dataset.title||"Aufgabe")}“ aus den Aufgabenlisten löschen? Die Historie bleibt erhalten.`);
+    if(!accepted)return;
+
+    button.disabled=true;
+    button.setAttribute("aria-busy","true");
+    try{
+      if(templateState){
+        const active=button.dataset.active==="true";
+        const result=await lifecycleCall("setTemplateActive",{templateId:id,active});
+        toast(active?`Template aktiviert${result?.resumedRules?` · ${result.resumedRules} Automatisierung(en) fortgesetzt`:""}.`:`Template deaktiviert${result?.pausedRules?` · ${result.pausedRules} Automatisierung(en) pausiert`:""}.`,"success");
+      }else if(templateDelete){
+        const result=await lifecycleCall("deleteTemplate",{templateId:id,reason:"Vom Manager in der Aufgabenverwaltung gelöscht"});
+        toast(`Template gelöscht${result?.deletedRules?` · ${result.deletedRules} Automatisierung(en) beendet`:""}.`,"success");
+      }else if(taskCancel){
+        await lifecycleCall("cancelTask",{taskId:id,reason:"Vom Manager in der Aufgabenverwaltung abgebrochen"});
+        toast("Aufgabe abgebrochen.","success");
+      }else if(taskDelete){
+        await lifecycleCall("deleteTask",{taskId:id,reason:"Vom Manager in der Aufgabenverwaltung gelöscht"});
+        toast("Aufgabe gelöscht.","success");
+      }
+      if(typeof globalThis.uEnsureManagerTasks==="function")await globalThis.uEnsureManagerTasks(true);
+      else scheduleReconcile(0);
+    }catch(error){
+      toast(safeError(error),"error");
+    }finally{
+      if(button.isConnected){button.disabled=false;button.removeAttribute("aria-busy")}
+    }
+  }
+  document.addEventListener("click",handleLifecycleClick,true);
+
+  // managerPunch and the worktime correction actions use a dedicated Edge Function,
+  // so they bypass apply() and therefore used to miss the normal workspace broadcast.
+  // Refresh the originating screen and notify every active workspace session before
+  // returning control to the UI.
+  if(typeof globalThis.request==="function"){
+    const baseRequest=globalThis.request;
+    globalThis.request=async function(functionName,body){
+      const result=await baseRequest(functionName,body);
+      const action=String(body?.action||"");
+      if(functionName===WORKTIME_FUNCTION&&WORKTIME_MUTATIONS.has(action)&&S?.session?.token){
+        await reconcileLiveState().catch(()=>{});
+        if(typeof globalThis.aoraBroadcastWorkspaceChange==="function"){
+          await globalThis.aoraBroadcastWorkspaceChange(
+            action==="managerPunch"?"MANAGER_DIRECT_PUNCH":"WORKTIME_MUTATION",
+            ["timeEntries","correctionRequests","notifications","audit","compliance"],
+            S.revision
+          ).catch(()=>{});
+        }
+      }
+      return result;
+    };
+    window.request=globalThis.request;
+  }
+
+  // Safari/PWA can miss a focus transition when returning from the kiosk tab.
+  // Reconcile on every foreground signal as an additional deterministic safety net.
+  window.addEventListener("pageshow",()=>scheduleReconcile(20));
+  window.addEventListener("focus",()=>scheduleReconcile(20));
+  document.addEventListener("visibilitychange",()=>{if(!document.hidden)scheduleReconcile(20)});
+  document.addEventListener("aora:workspace-change",()=>scheduleReconcile(40));
+})();

--- a/aora-v8-final/app/modules/runtime-hardening.js
+++ b/aora-v8-final/app/modules/runtime-hardening.js
@@ -53,13 +53,25 @@ const AORA_REALTIME_KEYS={
   KIOSK_TRANSITION:["clockRequests","notifications","audit"],CORRECTION_REQUESTED:["correctionRequests","compliance"],CORRECTION_DECIDED:["timeEntries","correctionRequests","audit","compliance"],
   EMPLOYEE_ANONYMIZED:["employees","timeEntries","audit","compliance"],INVITATION_ACTIVATED:["admins","invitations","audit"]
 };
+const AORA_CRITICAL_REALTIME_EVENTS=new Set(["KIOSK_TRANSITION","APPROVE_CLOCK_REQUEST","DENY_CLOCK_REQUEST"]);
 function notifyWorkspaceRealtime(eventType="WORKSPACE_CHANGED",keys=[],revision=S.revision){
   if(!S.session?.token||!navigator.onLine)return Promise.resolve({skipped:true});
   return request(CFG.realtimeBroadcastFunction,{token:S.session.token,eventType,keys,revision});
 }
-function scheduleWorkspaceBroadcast(eventType,keys,revision){
-  queueMicrotask(()=>notifyWorkspaceRealtime(eventType,keys,revision).catch(error=>reportClientDiagnostic?.("Realtime broadcast failed",error?.stack||String(error),"warning",{kind:"realtime-broadcast",eventType})));
+function reportRealtimeFailure(error,eventType){
+  try{
+    if(typeof reportClientDiagnostic==="function")reportClientDiagnostic("Realtime broadcast failed",error?.stack||String(error),"warning",{kind:"realtime-broadcast",eventType});
+    else console.warn("Realtime broadcast failed",eventType,error);
+  }catch{}
 }
+function scheduleWorkspaceBroadcast(eventType,keys,revision){
+  queueMicrotask(()=>notifyWorkspaceRealtime(eventType,keys,revision).catch(error=>reportRealtimeFailure(error,eventType)));
+}
+async function deliverWorkspaceBroadcast(eventType,keys,revision){
+  try{return await notifyWorkspaceRealtime(eventType,keys,revision)}
+  catch(error){reportRealtimeFailure(error,eventType);return{failed:true}}
+}
+globalThis.aoraBroadcastWorkspaceChange=deliverWorkspaceBroadcast;
 
 async function compliance(body){
   const result=await request(AORA_COMPLIANCE_FUNCTION,{...body,token:S.session?.token});
@@ -101,10 +113,19 @@ apply=async function(event){
   const result=await aoraBaseApply(event);
   if(!result?.pending){
     const eventType=String(event?.type||"WORKSPACE_CHANGED");
-    scheduleWorkspaceBroadcast(eventType,AORA_REALTIME_KEYS[eventType]||[],result?.revision??S.revision);
+    const keys=AORA_REALTIME_KEYS[eventType]||[];
+    if(AORA_CRITICAL_REALTIME_EVENTS.has(eventType)){
+      // Clock changes are user-visible immediately and often happen across kiosk/employee tabs.
+      // Do not fire-and-forget these broadcasts: iOS can suspend/close the originating tab before the request leaves.
+      await Promise.all([
+        deliverWorkspaceBroadcast(eventType,keys,result?.revision??S.revision),
+        typeof loadState==="function"?loadState(true).catch(()=>{}):Promise.resolve()
+      ]);
+    }else scheduleWorkspaceBroadcast(eventType,keys,result?.revision??S.revision);
   }
   return result;
 };
+window.apply=apply;
 const aoraBaseAcceptInvitation=acceptInvitation;
 acceptInvitation=async function(...args){
   const result=await aoraBaseAcceptInvitation(...args);
@@ -117,6 +138,7 @@ loadState=async function(quiet=false){
   if(S.session)connectWorkspaceRealtime().catch(()=>{});
   return result;
 };
+window.loadState=loadState;
 const aoraBaseLogout=logout;
 logout=async function(){
   await disconnectWorkspaceRealtime().catch(()=>{});

--- a/aora-v8-final/playwright.config.mjs
+++ b/aora-v8-final/playwright.config.mjs
@@ -45,7 +45,7 @@ export default defineConfig({
     {
       name:"chromium",
       dependencies:["mobile-layout"],
-      testMatch:/aora-(accessibility|four-role|unified-login|time-correction-clock-hub|navigation-qa|manager-task-composer)\.spec\.mjs/,
+      testMatch:/aora-(accessibility|four-role|unified-login|time-correction-clock-hub|navigation-qa|manager-task-composer|live-ui-sync)\.spec\.mjs/,
       use:desktop
     },
     {

--- a/aora-v8-final/tests/aora-live-ui-sync.spec.mjs
+++ b/aora-v8-final/tests/aora-live-ui-sync.spec.mjs
@@ -1,0 +1,97 @@
+import {test,expect} from "@playwright/test";
+
+const workspace=process.env.AORA_WORKSPACE_SLUG;
+const env=name=>{const value=process.env[name];if(!value)throw new Error(`Missing ${name}`);return value};
+const pathFor={manager:"/arbeitgeber/",employee:"/arbeitnehmer/",kiosk:"/kiosk/dashboard/"};
+const shellFor={manager:".admin-app",employee:".employee-app",kiosk:".kiosk-app"};
+
+function actionRequest(request,functionName,action){
+  return request.method()==="POST"&&request.url().includes(`/functions/v1/${functionName}`)&&String(request.postData()||"").includes(`"action":"${action}"`);
+}
+async function observe(page,predicate,trigger,allowed=[200,201]){
+  const responsePromise=page.waitForResponse(response=>predicate(response.request()),{timeout:30000});
+  await trigger();
+  const response=await responsePromise;
+  const body=await response.json().catch(()=>({}));
+  if(!allowed.includes(response.status()))throw new Error(`HTTP ${response.status()}: ${JSON.stringify(body).slice(0,300)}`);
+  return body;
+}
+async function login(page,role,email,password){
+  await page.goto(`${pathFor[role]}?workspace=${encodeURIComponent(workspace)}`);
+  await page.locator('input[name="email"]').fill(email);
+  await page.locator('input[name="password"]').fill(password);
+  await observe(page,request=>actionRequest(request,"aora-v8-pilot-access","passwordLogin"),()=>page.locator('#password-login button[type="submit"]').click());
+  await expect(page.locator(shellFor[role])).toBeVisible({timeout:30000});
+}
+async function kioskLogin(page){
+  await page.goto(`${pathFor.kiosk}?workspace=${encodeURIComponent(workspace)}`);
+  await page.locator('input[name="subject"]').fill(env("AORA_KIOSK_DEVICE_ID"));
+  await page.locator('input[name="pin"]').fill(env("AORA_KIOSK_PIN"));
+  await observe(page,request=>actionRequest(request,"aora-v8-pilot-access","login"),()=>page.locator('#pin-login button[type="submit"]').click());
+  await expect(page.locator(shellFor.kiosk)).toBeVisible({timeout:30000});
+}
+
+// Regression for the production iOS report: the visible Löschen button existed, but
+// the old bubbling document listener never reached the lifecycle Edge Function.
+test("Manager lifecycle buttons reach the API from the visible Tasks page",async({page})=>{
+  await login(page,"manager",env("AORA_MANAGER_EMAIL"),env("AORA_MANAGER_PASSWORD"));
+  await page.locator('.admin-nav [data-a="admin-view"][data-view="tasks"]').click();
+  const deleteButton=page.locator("[data-aora-template-delete]").first();
+  await expect(deleteButton).toBeVisible({timeout:30000});
+
+  const calls=[];
+  await page.route("**/functions/v1/aora-v8-task-lifecycle",async route=>{
+    const request=route.request();
+    let body={};
+    try{body=JSON.parse(request.postData()||"{}")}catch{}
+    if(body.action==="deleteTemplate"){
+      calls.push(body);
+      await route.fulfill({status:200,contentType:"application/json",body:JSON.stringify({request_id:"browser-test",data:{deleted:true,deletedRules:0},error:null})});
+      return;
+    }
+    await route.continue();
+  });
+  page.once("dialog",dialog=>dialog.accept());
+  await deleteButton.click();
+  await expect.poll(()=>calls.length,{timeout:10000}).toBe(1);
+  expect(String(calls[0].templateId||"").length).toBeGreaterThan(2);
+});
+
+// Regression for the production refresh report: kiosk -> employee and employee approval
+// must update without page.reload(). This deliberately uses separate browser contexts, so
+// the assertion depends on the server realtime fan-out rather than same-tab shared memory.
+test("Kiosk clock changes reconcile the Employee UI without reload",async({page,context,browser})=>{
+  await context.grantPermissions(["geolocation"]);
+  await context.setGeolocation({latitude:52.52,longitude:13.405,accuracy:20});
+  await login(page,"employee",env("AORA_EMPLOYEE_EMAIL"),env("AORA_EMPLOYEE_PASSWORD"));
+
+  const employeeId=await page.evaluate(()=>String(S.session?.subjectId||""));
+  const initiallyLive=await page.evaluate(id=>(S.state?.timeEntries||[]).some(item=>String(item.employeeId??item.employee_id)===id&&["live","paused"].includes(String(item.status||""))),employeeId);
+
+  const kioskContext=await browser.newContext();
+  const kiosk=await kioskContext.newPage();
+  await kioskLogin(kiosk);
+  await kiosk.locator(`[data-a="select-person"][data-id="${employeeId}"]`).click();
+
+  const firstTarget=initiallyLive?"out":"in";
+  await expect(kiosk.locator(`[data-a="transition"][data-target="${firstTarget}"]`)).toBeVisible({timeout:30000});
+  await kiosk.locator(`[data-a="transition"][data-target="${firstTarget}"]`).click();
+
+  // No employee.reload() here. Realtime must surface the pending confirmation.
+  await expect(page.locator('[data-a="clock-approve"]')).toBeVisible({timeout:30000});
+  await observe(page,request=>String(request.postData()||"").includes('"type":"APPROVE_CLOCK_REQUEST"'),()=>page.locator('[data-a="clock-approve"]').click());
+  await page.locator('.employee-bottom [data-view="time"]').click();
+  await expect(page.locator(".time-hub-clock-state")).toContainText(initiallyLive?"Nicht eingestempelt":"Eingestempelt",{timeout:30000});
+
+  // Return the isolated tenant to its original live/not-live state and verify the reverse path too.
+  await kiosk.locator(`[data-a="select-person"][data-id="${employeeId}"]`).click();
+  const secondTarget=initiallyLive?"in":"out";
+  await expect(kiosk.locator(`[data-a="transition"][data-target="${secondTarget}"]`)).toBeVisible({timeout:30000});
+  await kiosk.locator(`[data-a="transition"][data-target="${secondTarget}"]`).click();
+  await expect(page.locator('[data-a="clock-approve"]')).toBeVisible({timeout:30000});
+  await observe(page,request=>String(request.postData()||"").includes('"type":"APPROVE_CLOCK_REQUEST"'),()=>page.locator('[data-a="clock-approve"]').click());
+  await page.locator('.employee-bottom [data-view="time"]').click();
+  await expect(page.locator(".time-hub-clock-state")).toContainText(initiallyLive?"Eingestempelt":"Nicht eingestempelt",{timeout:30000});
+
+  await kioskContext.close();
+});


### PR DESCRIPTION
## Production bugs fixed
- Task/template `Löschen`, `Deaktivieren`, `Aktivieren` and task `Abbrechen` now use a capture-phase lifecycle handler so the visible button cannot be swallowed by nested/bubbling handlers before reaching `aora-v8-task-lifecycle`.
- Critical clock events (`KIOSK_TRANSITION`, `APPROVE_CLOCK_REQUEST`, `DENY_CLOCK_REQUEST`) now await the organization-wide realtime broadcast instead of fire-and-forget, then reconcile the originating UI state.
- Direct Worktime Center mutations (`managerPunch`, corrections) now also reconcile the workspace and broadcast a workspace invalidation to active sessions.
- Added iOS/PWA foreground reconciliation on pageshow/focus/visibility and workspace-change events.
- Bumped runtime cache keys to `v851` and added the live UI sync module.

## Why
Production Edge Function logs showed the reported Delete click never reached `aora-v8-task-lifecycle`, so the failure was in the frontend event path rather than Supabase lifecycle SQL/functionality. Clock mutations were persisted successfully, but the UI could remain stale. Existing E2E coverage also contained an explicit employee page reload between kiosk transitions, which masked this UX failure.

## Regression coverage
- Visible Manager lifecycle delete button must produce exactly one `deleteTemplate` request from the rendered Tasks page.
- Kiosk → Employee clock flow uses separate browser contexts and must surface the Employee clock approval and resulting worktime state without any page reload; the test then reverses the clock transition and verifies the reverse path as well.

Draft until the Pilot browser/release gate and related Aora gates are green.