### PR TITLE
Add Aora mobile PWA install support

### DIFF
--- a/aora-v8-final/app/index.html
+++ b/aora-v8-final/app/index.html
@@ -5,6 +5,12 @@
 <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
 <meta name="theme-color" content="#ffffff">
 <meta name="description" content="AoraAI Workforce 8.1.3 Production">
+<meta name="application-name" content="Aora">
+<meta name="mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-title" content="Aora">
+<meta name="apple-mobile-web-app-status-bar-style" content="default">
+<link rel="manifest" href="/manifest.webmanifest">
 <base href="/">
 <title>AoraAI Workforce</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/aora-v8-final/app/manifest.webmanifest
+++ b/aora-v8-final/app/manifest.webmanifest
@@ -15,21 +15,15 @@
   "prefer_related_applications": false,
   "icons": [
     {
-      "src": "/icons/aora-192.png",
-      "sizes": "192x192",
-      "type": "image/png",
+      "src": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA1MTIgNTEyIj48cmVjdCB3aWR0aD0iNTEyIiBoZWlnaHQ9IjUxMiIgcng9Ijk2IiBmaWxsPSIjMDAwIi8+PHBhdGggZD0iTTE0NCAzNjMgMjE5IDE0NWM4LTI0IDIxLTM3IDM3LTM3czI5IDEzIDM3IDM3bDc1IDIxOCIgZmlsbD0ibm9uZSIgc3Ryb2tlPSIjZmZmIiBzdHJva2Utd2lkdGg9IjM4IiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiLz48Y2lyY2xlIGN4PSIyNTYiIGN5PSIyNTEiIHI9IjI0IiBmaWxsPSIjZmZmIi8+PC9zdmc+",
+      "sizes": "192x192 512x512",
+      "type": "image/svg+xml",
       "purpose": "any"
     },
     {
-      "src": "/icons/aora-512.png",
+      "src": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA1MTIgNTEyIj48cmVjdCB3aWR0aD0iNTEyIiBoZWlnaHQ9IjUxMiIgZmlsbD0iIzAwMCIvPjxwYXRoIGQ9Ik0xNjcgMzQ1IDIyNSAxNzdjNy0yMCAxNy0zMCAzMS0zMHMyNCAxMCAzMSAzMGw1OCAxNjgiIGZpbGw9Im5vbmUiIHN0cm9rZT0iI2ZmZiIgc3Ryb2tlLXdpZHRoPSIzNCIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2UtbGluZWpvaW49InJvdW5kIi8+PGNpcmNsZSBjeD0iMjU2IiBjeT0iMjUzIiByPSIyMCIgZmlsbD0iI2ZmZiIvPjwvc3ZnPg==",
       "sizes": "512x512",
-      "type": "image/png",
-      "purpose": "any"
-    },
-    {
-      "src": "/icons/aora-maskable-512.png",
-      "sizes": "512x512",
-      "type": "image/png",
+      "type": "image/svg+xml",
       "purpose": "maskable"
     }
   ]

--- a/aora-v8-final/app/manifest.webmanifest
+++ b/aora-v8-final/app/manifest.webmanifest
@@ -1,0 +1,36 @@
+{
+  "id": "/",
+  "name": "AoraAI Workforce",
+  "short_name": "Aora",
+  "description": "AoraAI Workforce für Zeiterfassung, Aufgaben, Schichten und Teamarbeit.",
+  "lang": "de-DE",
+  "dir": "ltr",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#ffffff",
+  "orientation": "any",
+  "categories": ["business", "productivity"],
+  "prefer_related_applications": false,
+  "icons": [
+    {
+      "src": "/icons/aora-192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "any"
+    },
+    {
+      "src": "/icons/aora-512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any"
+    },
+    {
+      "src": "/icons/aora-maskable-512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "maskable"
+    }
+  ]
+}


### PR DESCRIPTION
Adds the Aora web app manifest and mobile standalone metadata. Preserves the existing service worker and offline time-tracking flow. Vercel preview build passed.