### PR TITLE
Harden DATEV LODAS export validation

### DIFF
--- a/aora-v8-final/app/index.html
+++ b/aora-v8-final/app/index.html
@@ -105,7 +105,7 @@
 <script src="modules/worktime-document-bridge.js?v=839" defer></script>
 <script src="modules/employee-document-notifications.js?v=843" defer></script>
 <script src="modules/timesheet-current-period-guard.js?v=844" defer></script>
-<script src="modules/pruefung-export-center.js?v=866" defer></script>
+<script src="modules/pruefung-export-center.js?v=869" defer></script>
 <script src="https://cdn.jsdelivr.net/npm/jsqr@1.4.0/dist/jsQR.js" defer></script>
 <script src="modules/inventory-core.js?v=863" defer></script>
 <script src="modules/inventory-session-contract.js?v=862" defer></script>

--- a/aora-v8-final/app/modules/pruefung-export-center.js
+++ b/aora-v8-final/app/modules/pruefung-export-center.js
@@ -78,7 +78,7 @@
     if(Number(totals.openEntries)>0)notes.push(`${Number(totals.openEntries)} offene/laufende Buchung${Number(totals.openEntries)===1?"":"en"} zuerst abschließen.`);
     if(Number(totals.missingPersonnelNumbers)>0)notes.push(`${Number(totals.missingPersonnelNumbers)} DATEV-Personalnummer${Number(totals.missingPersonnelNumbers)===1?" fehlt":"n fehlen"}.`);
     if(!Number(totals.minutes)&&!Number(totals.openEntries))notes.push("Im gewählten Monat sind noch keine abgeschlossenen Stunden vorhanden.");
-    if(!notes.length)return'<div class="pruefung-alert ok"><strong>Export bereit.</strong><span>Es werden nur abgeschlossene Arbeitsstunden ausgegeben.</span></div>';
+    if(!notes.length)return'<div class="pruefung-alert ok"><strong>Export bereit.</strong><span>Es werden nur abgeschlossene Arbeitsstunden ausgegeben. Fachliche DATEV-Validierung erfolgt erst nach erfolgreichem Testimport in LODAS.</span></div>';
     return`<div class="pruefung-alert"><strong>Vor dem Export</strong><ul>${notes.map(note=>`<li>${html(note)}</li>`).join("")}</ul></div>`;
   }
 
@@ -87,7 +87,7 @@
     if(!employees.length)return'<div class="empty">Keine Mitarbeiter mit Arbeitszeit im gewählten Monat.</div>';
     return`<div class="datev-hours-mapping-list">${employees.map(employee=>`<label class="datev-hours-mapping-row">
       <span><strong>${html(employee.name)}</strong><small>${html(formatHours(employee.minutes))}${employee.openEntries?` · ${employee.openEntries} offen`:""}</small></span>
-      <input class="input" name="personnel-${html(employee.id)}" inputmode="numeric" pattern="[0-9]{1,9}" maxlength="9" autocomplete="off" placeholder="Personalnr." value="${html(employee.personnelNumber||"")}">
+      <input class="input" name="personnel-${html(employee.id)}" inputmode="numeric" pattern="[0-9]{1,5}" maxlength="5" autocomplete="off" placeholder="Personalnr." value="${html(employee.personnelNumber||"")}">
     </label>`).join("")}</div>`;
   }
 
@@ -103,7 +103,7 @@
         <label>Mandantennummer<input class="input" name="mandantNumber" inputmode="numeric" pattern="[0-9]{1,5}" minlength="1" maxlength="5" autocomplete="off" value="${html(settings.mandant_number||"")}" required></label>
         <label>Lohnart Arbeitsstunden<input class="input" name="regularWageType" inputmode="numeric" pattern="[0-9]{1,4}" minlength="1" maxlength="4" autocomplete="off" placeholder="Vom Steuerberater" value="${html(settings.regular_wage_type||"")}" required></label>
       </div>
-      <div class="datev-hours-config-head"><strong>Personalnummern</strong><small>Nur für Mitarbeiter mit Stunden in diesem Monat.</small></div>
+      <div class="datev-hours-config-head"><strong>Personalnummern</strong><small>1–99999 · nur für Mitarbeiter mit Stunden in diesem Monat.</small></div>
       ${employeeMappingRows()}
       <div class="datev-hours-config-actions"><button class="btn outline" type="submit">Zuordnung speichern</button></div>
     </form>`;
@@ -121,7 +121,7 @@
       </div>
       ${readinessNotice()}
       <details class="datev-hours-settings" ${data?.settings?"":"open"}><summary>DATEV-Zuordnung</summary>${configForm()}</details>
-      <p class="datev-hours-footnote">LODAS Bewegungsdaten · Stundenbuchung. Lohnart und Personalnummern werden nicht geraten, sondern nach Vorgabe des Steuerberaters hinterlegt.</p>
+      <p class="datev-hours-footnote">LODAS Bewegungsdaten · Stundenbuchung. Lohnart und Personalnummern werden nicht geraten, sondern nach Vorgabe des Steuerberaters hinterlegt. Status: Testimport in DATEV LODAS noch ausstehend.</p>
     </article>`;
   }
 
@@ -167,7 +167,7 @@
       const filename=disposition.match(/filename="?([^";]+)"?/i)?.[1]||`AORA_DATEV_LODAS_STUNDEN_${datevState.period}.txt`;
       const url=URL.createObjectURL(blob),anchor=document.createElement("a");
       anchor.href=url;anchor.download=filename;anchor.hidden=true;document.body.appendChild(anchor);anchor.click();anchor.remove();setTimeout(()=>URL.revokeObjectURL(url),1000);
-      return{filename,checksum:response.headers.get("x-aora-export-checksum")};
+      return{filename,checksum:response.headers.get("x-aora-export-checksum"),validation:response.headers.get("x-aora-datev-validation")};
     }catch(error){
       if(error?.name==="AbortError")throw new Error("DATEV-Stundenexport hat zu lange gedauert.");
       throw error;
@@ -227,7 +227,7 @@
       }
       if(action==="export"){
         const result=await downloadExport();
-        toast(`${result.filename} wurde erstellt.`,"success");
+        toast(`${result.filename} wurde erstellt. DATEV-Testimport steht noch aus.`,"success");
       }
     }catch(error){
       toast(error?.message||"DATEV-Aktion fehlgeschlagen.","error");

--- a/aora-v8-final/supabase/functions/aora-v8-datev-hours-export/index.ts
+++ b/aora-v8-final/supabase/functions/aora-v8-datev-hours-export/index.ts
@@ -34,7 +34,7 @@ function cors(origin:string|null){
     "Access-Control-Allow-Origin":origin&&originAllowed(origin)?origin:DEFAULT_ORIGIN,
     "Access-Control-Allow-Headers":"content-type",
     "Access-Control-Allow-Methods":"POST,OPTIONS",
-    "Access-Control-Expose-Headers":"content-disposition,x-aora-export-checksum,x-aora-export-period",
+    "Access-Control-Expose-Headers":"content-disposition,x-aora-export-checksum,x-aora-export-period,x-aora-datev-validation",
     "Access-Control-Max-Age":"600",
     "Cache-Control":"no-store",
     "X-Content-Type-Options":"nosniff",
@@ -52,6 +52,12 @@ const clean=(value:unknown)=>String(value??"").replace(/\s+/g," ").trim();
 function digits(value:unknown,min:number,max:number,label:string){
   const result=clean(value);
   if(!new RegExp(`^\\d{${min},${max}}$`).test(result))fail(`${label} ist ungültig.`,400,"invalid_datev_mapping");
+  return result;
+}
+function datevPersonnelNumber(value:unknown){
+  const result=digits(value,1,5,"Personalnummer");
+  const numeric=Number(result);
+  if(!Number.isInteger(numeric)||numeric<1||numeric>99999)fail("Personalnummer muss zwischen 1 und 99999 liegen.",400,"invalid_datev_personnel_number");
   return result;
 }
 function monthValue(value:unknown){
@@ -181,7 +187,7 @@ async function status(ctx:any,body:any){
     return{id:String(employee.id),name:clean(employee.name||"Mitarbeiter/in"),locationId:employeeLocation(employee),active:employee.active!==false,personnelNumber:mapping?.personnel_number||null,minutes:totals.minutes,entries:totals.entries,openEntries:totals.openEntries,included:totals.minutes>0||totals.openEntries>0};
   });
   const included=employees.filter((employee:any)=>employee.included);
-  return{period,targetSystem:"datev_lodas",settings,employees,totals:{employees:included.length,minutes:included.reduce((sum:number,employee:any)=>sum+Number(employee.minutes||0),0),openEntries:included.reduce((sum:number,employee:any)=>sum+Number(employee.openEntries||0),0),missingPersonnelNumbers:included.filter((employee:any)=>!employee.personnelNumber).length},canConfigure:["owner","manager"].includes(ctx.accessRole)};
+  return{period,targetSystem:"datev_lodas",settings,employees,totals:{employees:included.length,minutes:included.reduce((sum:number,employee:any)=>sum+Number(employee.minutes||0),0),openEntries:included.reduce((sum:number,employee:any)=>sum+Number(employee.openEntries||0),0),missingPersonnelNumbers:included.filter((employee:any)=>!employee.personnelNumber).length},canConfigure:["owner","manager"].includes(ctx.accessRole),validationStatus:"not_test_imported"};
 }
 async function saveConfig(ctx:any,body:any){
   requireManager(ctx);
@@ -198,7 +204,7 @@ async function saveConfig(ctx:any,body:any){
     if(!visibleIds.has(employeeId))fail("Mitarbeiter-Zuordnung ist nicht zulässig.",403,"employee_mapping_scope");
     const rawPersonnel=clean(mapping.personnelNumber);
     if(!rawPersonnel)return{employeeId,personnelNumber:null as string|null};
-    const personnelNumber=digits(rawPersonnel,1,9,"Personalnummer");
+    const personnelNumber=datevPersonnelNumber(rawPersonnel);
     if(seenPersonnel.has(personnelNumber))fail(`Personalnummer ${personnelNumber} ist doppelt vergeben.`,409,"duplicate_personnel_number");
     seenPersonnel.add(personnelNumber);
     return{employeeId,personnelNumber};
@@ -230,7 +236,7 @@ async function createExport(ctx:any,body:any,origin:string|null){
   const open=includedEmployees.filter((employee:any)=>Number(summary.get(String(employee.id))?.openEntries||0)>0);
   if(open.length)fail("Offene oder laufende Arbeitszeitbuchungen müssen vor dem DATEV-Export abgeschlossen werden.",409,"datev_hours_open_entries",open.map((employee:any)=>clean(employee.name)));
   const mappings=await mappingRows(ctx,includedEmployees.map((employee:any)=>String(employee.id)));
-  const mappingMap=new Map(mappings.map((row:any)=>[String(row.employee_id),String(row.personnel_number)]));
+  const mappingMap=new Map(mappings.map((row:any)=>[String(row.employee_id),datevPersonnelNumber(row.personnel_number)]));
   const missing=includedEmployees.filter((employee:any)=>!mappingMap.get(String(employee.id)));
   if(missing.length)fail("Für alle Mitarbeiter mit Stunden wird eine DATEV-Personalnummer benötigt.",409,"datev_personnel_number_missing",missing.map((employee:any)=>({id:String(employee.id),name:clean(employee.name)})));
   const used=new Set<string>();
@@ -260,10 +266,10 @@ async function createExport(ctx:any,body:any,origin:string|null){
   if(bytes.length>MAX_EXPORT_BYTES)fail("DATEV-Stundenexport überschreitet 3 MB.",413,"datev_hours_too_large");
   const checksum=await sha256(bytes);
   const totalMinutes=includedEmployees.reduce((sum:number,employee:any)=>sum+Number(summary.get(String(employee.id))?.minutes||0),0);
-  const{error:logError}=await service.from("datev_hours_export_runs").insert({organization_id:ctx.organization.id,period,target_system:"datev_lodas",row_count:rows.length,total_minutes:totalMinutes,checksum_sha256:checksum,created_by:String(ctx.session.subject_id),metadata:{kind:"regular_hours_only",bookingKey:"01",wageType:settings.regular_wage_type,scope:ctx.accessRole,managerLocationIds:ctx.accessRole==="manager"?ctx.locationIds:[]}});
+  const{error:logError}=await service.from("datev_hours_export_runs").insert({organization_id:ctx.organization.id,period,target_system:"datev_lodas",row_count:rows.length,total_minutes:totalMinutes,checksum_sha256:checksum,created_by:String(ctx.session.subject_id),metadata:{kind:"regular_hours_only",bookingKey:"01",wageType:settings.regular_wage_type,scope:ctx.accessRole,managerLocationIds:ctx.accessRole==="manager"?ctx.locationIds:[],validationStatus:"not_test_imported"}});
   if(logError)throw logError;
   const filename=`AORA_DATEV_LODAS_STUNDEN_${period}.txt`;
-  return new Response(bytes,{status:200,headers:{...cors(origin),"Content-Type":"text/plain; charset=us-ascii","Content-Disposition":`attachment; filename=${filename}`,"X-Aora-Export-Checksum":checksum,"X-Aora-Export-Period":period}});
+  return new Response(bytes,{status:200,headers:{...cors(origin),"Content-Type":"text/plain; charset=us-ascii","Content-Disposition":`attachment; filename=${filename}`,"X-Aora-Export-Checksum":checksum,"X-Aora-Export-Period":period,"X-Aora-Datev-Validation":"not-test-imported"}});
 }
 
 Deno.serve(async(req:Request)=>{

--- a/aora-v8-final/supabase/migrations/20260821211500_tighten_datev_lodas_personnel_number.sql
+++ b/aora-v8-final/supabase/migrations/20260821211500_tighten_datev_lodas_personnel_number.sql
@@ -7,9 +7,10 @@ begin
   if exists (
     select 1
     from public.datev_hours_employee_mappings
-    where personnel_number !~ '^\d{1,5}$'
-       or personnel_number::integer < 1
-       or personnel_number::integer > 99999
+    where not case
+      when personnel_number ~ '^\d{1,5}$' then personnel_number::integer between 1 and 99999
+      else false
+    end
   ) then
     raise exception 'Cannot tighten DATEV personnel-number constraint: incompatible mappings exist';
   end if;
@@ -21,8 +22,10 @@ alter table public.datev_hours_employee_mappings
 alter table public.datev_hours_employee_mappings
   add constraint datev_hours_employee_mappings_personnel_number_check
   check (
-    personnel_number ~ '^\d{1,5}$'
-    and personnel_number::integer between 1 and 99999
+    case
+      when personnel_number ~ '^\d{1,5}$' then personnel_number::integer between 1 and 99999
+      else false
+    end
   );
 
 commit;

--- a/aora-v8-final/supabase/migrations/20260821211500_tighten_datev_lodas_personnel_number.sql
+++ b/aora-v8-final/supabase/migrations/20260821211500_tighten_datev_lodas_personnel_number.sql
@@ -1,0 +1,28 @@
+begin;
+
+-- DATEV LODAS Personalnummer is limited to 1..99999 for this hours export.
+-- Existing mappings are checked before tightening the database constraint.
+do $$
+begin
+  if exists (
+    select 1
+    from public.datev_hours_employee_mappings
+    where personnel_number !~ '^\d{1,5}$'
+       or personnel_number::integer < 1
+       or personnel_number::integer > 99999
+  ) then
+    raise exception 'Cannot tighten DATEV personnel-number constraint: incompatible mappings exist';
+  end if;
+end $$;
+
+alter table public.datev_hours_employee_mappings
+  drop constraint if exists datev_hours_employee_mappings_personnel_number_check;
+
+alter table public.datev_hours_employee_mappings
+  add constraint datev_hours_employee_mappings_personnel_number_check
+  check (
+    personnel_number ~ '^\d{1,5}$'
+    and personnel_number::integer between 1 and 99999
+  );
+
+commit;

--- a/aora-v8-final/tests/pruefung-datev-hours-source.mjs
+++ b/aora-v8-final/tests/pruefung-datev-hours-source.mjs
@@ -5,6 +5,7 @@ const ui=fs.readFileSync(new URL('../app/modules/pruefung-export-center.js',impo
 const css=fs.readFileSync(new URL('../app/pruefung-export-center.css',import.meta.url),'utf8');
 const edge=fs.readFileSync(new URL('../supabase/functions/aora-v8-datev-hours-export/index.ts',import.meta.url),'utf8');
 const migration=fs.readFileSync(new URL('../supabase/migrations/20260821191000_aora_datev_hours_export_prod.sql',import.meta.url),'utf8');
+const tightenMigration=fs.readFileSync(new URL('../supabase/migrations/20260821211500_tighten_datev_lodas_personnel_number.sql',import.meta.url),'utf8');
 const index=fs.readFileSync(new URL('../app/index.html',import.meta.url),'utf8');
 
 // Prüfung & Exporte is the single manager entry for DATEV hours and employee signatures.
@@ -41,6 +42,22 @@ assert.match(edge,/MAX_EXPORT_BYTES=3\*1024\*1024/);
 assert.match(edge,/datev_hours_open_entries/);
 assert.match(edge,/datev_personnel_number_missing/);
 assert.match(edge,/duplicate_personnel_number/);
+
+// LODAS personnel numbers are constrained to 1..99999 at UI, API and DB layers.
+assert.match(ui,/pattern="\[0-9\]\{1,5\}" maxlength="5"/);
+assert.match(ui,/1–99999/);
+assert.match(edge,/function datevPersonnelNumber\(value:unknown\)/);
+assert.match(edge,/digits\(value,1,5,"Personalnummer"\)/);
+assert.match(edge,/numeric<1\|\|numeric>99999/);
+assert.match(edge,/datevPersonnelNumber\(row\.personnel_number\)/);
+assert.match(tightenMigration,/personnel_number ~ '\^\\d\{1,5\}\$'/);
+assert.match(tightenMigration,/between 1 and 99999/);
+
+// AORA must never claim actual DATEV validation before a successful real test import.
+assert.match(edge,/validationStatus:"not_test_imported"/);
+assert.match(edge,/X-Aora-Datev-Validation":"not-test-imported"/);
+assert.match(ui,/DATEV-Testimport steht noch aus/);
+assert.match(ui,/Testimport in DATEV LODAS noch ausstehend/);
 
 // Manager scope includes cross-location work at accessible locations, with employee-location fallback for older entries.
 assert.match(edge,/const explicitLocationId=entryLocationId\(entry\)/);


### PR DESCRIPTION
## Scope
- Tighten DATEV LODAS personnel numbers to `1..99999` consistently in UI, Edge Function and DB constraint.
- Validate stored personnel numbers again at export time (defense in depth).
- Mark generated exports explicitly as `not_test_imported` until an actual DATEV LODAS test import succeeds.
- Keep existing Beraternummer, Mandantennummer and Lohnart configuration behavior unchanged; no values are guessed.
- Cache-bump the Prüfung & Exporte module.

## Safety
- No workforce, employee, shift or time-entry data is rewritten.
- The migration refuses to tighten the constraint if incompatible personnel mappings already exist.
- Current production mappings 1..7 are inside the new allowed range.

## Important validation boundary
This PR improves structural validation only. DATEV itself states that full ASCII validation requires a test import in the DATEV application. Sandbox upload alone cannot perform that import; production acceptance must use a designated test system with sample data only.